### PR TITLE
feat: website to control ctxtrans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,19 @@ all: build
 .PHONY: build
 build:
 	@echo "Building ${BINARY_NAME}..."
-	@go build ${LDFLAGS} -o ${BINARY_NAME} ./cmd/ctxtrans
+	@go build ${LDFLAGS} -o ${BINARY_NAME} ./cmd
 
 # 安装到 $GOPATH/bin
 .PHONY: install
 install:
 	@echo "Installing ${BINARY_NAME}..."
-	@go install ${LDFLAGS} ./cmd/ctxtrans
+	@go install ${LDFLAGS} ./cmd
+
+# 运行应用
+.PHONY: run
+run: build
+	@echo "Running ${BINARY_NAME}..."
+	@UI_STATIC_DIR=$(CURDIR)/web/dist ./${BINARY_NAME}
 
 # 清理构建文件
 .PHONY: clean
@@ -96,6 +102,7 @@ example:
 help:
 	@echo "Available targets:"
 	@echo "  build        - Build the binary"
+	@echo "  run          - Build and run the application"
 	@echo "  install      - Install to \$$GOPATH/bin"
 	@echo "  test         - Run tests"
 	@echo "  test-coverage- Run tests with coverage"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,52 +2,113 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/MimeLyc/contextual-sub-translator/internal/httpapi"
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/MimeLyc/contextual-sub-translator/internal/library"
+	"github.com/MimeLyc/contextual-sub-translator/internal/media"
 	"github.com/MimeLyc/contextual-sub-translator/internal/service"
 	"github.com/robfig/cron/v3"
 )
 
+type scheduler interface {
+	Schedule(ctx context.Context) error
+}
+
+type cronEngine interface {
+	Start()
+	Stop() context.Context
+}
+
+type httpEngine interface {
+	ListenAndServe(addr string) error
+	Shutdown(ctx context.Context) error
+}
+
 func main() {
+	settingsFile := config.RuntimeSettingsFilePath()
+	configOpts := make([]config.Option, 0, 1)
+	if settings, err := config.LoadRuntimeSettingsFile(settingsFile); err == nil {
+		configOpts = append(configOpts, config.WithRuntimeSettings(settings))
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Printf("warning: failed to load runtime settings file %s: %v", settingsFile, err)
+	}
+
 	// Initialize configuration
-	cfg, err := config.NewFromEnv()
+	cfg, err := config.NewFromEnv(configOpts...)
 	if err != nil {
 		log.Fatal("Failed to load configuration:", err)
+	}
+
+	settingsStore, err := config.NewRuntimeSettingsStore(settingsFile, cfg.RuntimeSettings())
+	if err != nil {
+		log.Fatal("Failed to initialize runtime settings store:", err)
 	}
 
 	// Create a context that listens for interrupt signals
 	ctx, cancel := signalContext(context.Background())
 	defer cancel()
 
-	// Start cron service
-	cron := cron.New()
-	cronSvc := service.NewRunnableTransService(*cfg, cron)
+	cronScheduler := cron.New()
+	jobQueue := jobs.NewQueue(max(1, cfg.Agent.BundleConcurrency))
+	cronSvc := service.NewRunnableTransServiceWithQueue(*cfg, cronScheduler, jobQueue)
 
-	err = cronSvc.Schedule(ctx)
-	if err != nil {
-		log.Fatal("Failed to schedule service:", err)
+	sourceConfigs := []library.SourceConfig{
+		{ID: "movies", Name: "Movies", Path: cfg.Media.MovieDir},
+		{ID: "animations", Name: "Animations", Path: cfg.Media.AnimationDir},
+		{ID: "teleplays", Name: "Teleplays", Path: cfg.Media.TeleplayDir},
+		{ID: "tvshows", Name: "TV Shows", Path: cfg.Media.ShowDir},
+		{ID: "documentaries", Name: "Documentaries", Path: cfg.Media.DocumentaryDir},
 	}
+	scanner := library.NewScanner(
+		sourceConfigs,
+		cfg.Translate.TargetLanguage,
+		library.WithEmbeddedDetector(func(mediaPath string) (bool, bool, []string) {
+			descriptions, err := media.NewOperator(mediaPath).ReadSubtitleDescription()
+			if err != nil {
+				return false, false, nil
+			}
+			langs := make([]string, 0, len(descriptions))
+			seen := make(map[string]bool)
+			for _, d := range descriptions {
+				lang := d.Language
+				if lang == "" {
+					lang = "und"
+				}
+				if !seen[lang] {
+					seen[lang] = true
+					langs = append(langs, lang)
+				}
+			}
+			return len(descriptions) > 0, descriptions.HasLanguage(cfg.Translate.TargetLanguage), langs
+		}),
+	)
+	httpSrv := httpapi.NewServer(
+		scanner,
+		jobQueue,
+		httpapi.WithRuntimeSettingsStore(settingsStore),
+		httpapi.WithRuntimeSettingsApplier(func(next config.RuntimeSettings) error {
+			if err := cronSvc.ApplyRuntimeSettings(next); err != nil {
+				return err
+			}
+			return scanner.UpdateTargetLanguage(next.TargetLanguage)
+		}),
+		httpapi.WithUI(cfg.HTTP.UIStaticDir, cfg.HTTP.UIEnabled),
+	)
 
-	cron.Start()
-
-	// Keep the main routine alive until termination
-	log.Println("Service started, waiting for interrupt signal...")
-	<-ctx.Done()
-
-	log.Println("Received termination signal, shutting down...")
-
-	// Graceful shutdown
-	_, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer shutdownCancel()
-
-	cron.Stop()
-
-	log.Println("Service shutdown complete")
+	err = runWithComponents(ctx, cfg, &cronSvc, cronScheduler, httpSrv)
+	if err != nil {
+		log.Fatal("Failed to run services:", err)
+	}
 }
 
 // signalContext returns a context that is cancelled when SIGINT or SIGTERM is received
@@ -68,4 +129,50 @@ func signalContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	}()
 
 	return ctx, cancel
+}
+
+func runWithComponents(
+	ctx context.Context,
+	cfg *config.Config,
+	cronSvc scheduler,
+	cronScheduler cronEngine,
+	httpSrv httpEngine,
+) error {
+	if err := cronSvc.Schedule(ctx); err != nil {
+		return fmt.Errorf("failed to schedule service: %w", err)
+	}
+
+	cronScheduler.Start()
+
+	httpErrCh := make(chan error, 1)
+	if cfg.HTTP.UIEnabled {
+		go func() {
+			err := httpSrv.ListenAndServe(cfg.HTTP.Addr)
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				httpErrCh <- err
+			}
+		}()
+	}
+
+	log.Println("Service started, waiting for interrupt signal...")
+
+	select {
+	case <-ctx.Done():
+	case err := <-httpErrCh:
+		return fmt.Errorf("http server failed: %w", err)
+	}
+
+	log.Println("Received termination signal, shutting down...")
+	cronScheduler.Stop()
+
+	if cfg.HTTP.UIEnabled {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer shutdownCancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("failed to shutdown http server: %w", err)
+		}
+	}
+
+	log.Println("Service shutdown complete")
+	return nil
 }

--- a/cmd/main_http_test.go
+++ b/cmd/main_http_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeScheduler struct {
+	called bool
+}
+
+func (f *fakeScheduler) Schedule(context.Context) error {
+	f.called = true
+	return nil
+}
+
+type fakeCron struct {
+	started bool
+	stopped bool
+}
+
+func (f *fakeCron) Start() {
+	f.started = true
+}
+
+func (f *fakeCron) Stop() context.Context {
+	f.stopped = true
+	return context.Background()
+}
+
+type fakeHTTP struct {
+	listenCalled chan struct{}
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+func newFakeHTTP() *fakeHTTP {
+	return &fakeHTTP{
+		listenCalled: make(chan struct{}),
+		shutdownCh:   make(chan struct{}),
+	}
+}
+
+func (f *fakeHTTP) ListenAndServe(string) error {
+	close(f.listenCalled)
+	<-f.shutdownCh
+	return http.ErrServerClosed
+}
+
+func (f *fakeHTTP) Shutdown(context.Context) error {
+	f.shutdownOnce.Do(func() { close(f.shutdownCh) })
+	return nil
+}
+
+func TestMain_StartsCronAndHTTP(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &config.Config{
+		HTTP: config.HTTPConfig{
+			Addr:      "127.0.0.1:0",
+			UIEnabled: true,
+		},
+	}
+	scheduler := &fakeScheduler{}
+	cronEngine := &fakeCron{}
+	httpSrv := newFakeHTTP()
+
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- runWithComponents(ctx, cfg, scheduler, cronEngine, httpSrv)
+	}()
+
+	select {
+	case <-httpSrv.listenCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("http server did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-doneCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWithComponents did not exit after cancellation")
+	}
+
+	assert.True(t, scheduler.called)
+	assert.True(t, cronEngine.started)
+	assert.True(t, cronEngine.stopped)
+}

--- a/internal/config/config_http_test.go
+++ b/internal/config/config_http_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromEnv_HTTPDefaults(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "test-key")
+
+	cfg, err := NewFromEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, ":8080", cfg.HTTP.Addr)
+	assert.Equal(t, "/app/web", cfg.HTTP.UIStaticDir)
+	assert.True(t, cfg.HTTP.UIEnabled)
+}
+

--- a/internal/config/runtime_settings.go
+++ b/internal/config/runtime_settings.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/robfig/cron/v3"
+	"golang.org/x/text/language"
+)
+
+const DefaultRuntimeSettingsFile = "/app/config/settings.json"
+
+type RuntimeSettings struct {
+	LLMAPIURL      string `json:"llm_api_url"`
+	LLMAPIKey      string `json:"llm_api_key"`
+	LLMModel       string `json:"llm_model"`
+	CronExpr       string `json:"cron_expr"`
+	TargetLanguage string `json:"target_language"`
+}
+
+func RuntimeSettingsFilePath() string {
+	return getEnvString("SETTINGS_FILE", DefaultRuntimeSettingsFile)
+}
+
+func (s RuntimeSettings) Validate() error {
+	if strings.TrimSpace(s.LLMAPIURL) == "" {
+		return fmt.Errorf("llm_api_url is required")
+	}
+	if strings.TrimSpace(s.LLMAPIKey) == "" {
+		return fmt.Errorf("llm_api_key is required")
+	}
+	if strings.TrimSpace(s.LLMModel) == "" {
+		return fmt.Errorf("llm_model is required")
+	}
+	if strings.TrimSpace(s.CronExpr) == "" {
+		return fmt.Errorf("cron_expr is required")
+	}
+	if _, err := cron.ParseStandard(s.CronExpr); err != nil {
+		return fmt.Errorf("invalid cron_expr: %w", err)
+	}
+	if strings.TrimSpace(s.TargetLanguage) == "" {
+		return fmt.Errorf("target_language is required")
+	}
+	if _, err := language.Parse(s.TargetLanguage); err != nil {
+		return fmt.Errorf("invalid target_language: %w", err)
+	}
+	return nil
+}
+
+func (c *Config) RuntimeSettings() RuntimeSettings {
+	return RuntimeSettings{
+		LLMAPIURL:      c.LLM.APIURL,
+		LLMAPIKey:      c.LLM.APIKey,
+		LLMModel:       c.LLM.Model,
+		CronExpr:       c.Translate.CronExpr,
+		TargetLanguage: c.Translate.TargetLanguage.String(),
+	}
+}
+
+func WithRuntimeSettings(settings RuntimeSettings) Option {
+	return func(c *Config) {
+		if strings.TrimSpace(settings.LLMAPIURL) != "" {
+			c.LLM.APIURL = settings.LLMAPIURL
+		}
+		if strings.TrimSpace(settings.LLMAPIKey) != "" {
+			c.LLM.APIKey = settings.LLMAPIKey
+		}
+		if strings.TrimSpace(settings.LLMModel) != "" {
+			c.LLM.Model = settings.LLMModel
+		}
+		if strings.TrimSpace(settings.CronExpr) != "" {
+			c.Translate.CronExpr = settings.CronExpr
+		}
+		if tag, err := language.Parse(settings.TargetLanguage); err == nil {
+			c.Translate.TargetLanguage = tag
+		}
+	}
+}
+
+func LoadRuntimeSettingsFile(path string) (RuntimeSettings, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return RuntimeSettings{}, err
+	}
+	var settings RuntimeSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return RuntimeSettings{}, fmt.Errorf("invalid settings file: %w", err)
+	}
+	return settings, nil
+}
+
+func WriteRuntimeSettingsFile(path string, settings RuntimeSettings) error {
+	if err := settings.Validate(); err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	content, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, content, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+type RuntimeSettingsStore struct {
+	path string
+
+	mu      sync.RWMutex
+	current RuntimeSettings
+}
+
+func NewRuntimeSettingsStore(path string, initial RuntimeSettings) (*RuntimeSettingsStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("settings file path is required")
+	}
+	if err := initial.Validate(); err != nil {
+		return nil, err
+	}
+	return &RuntimeSettingsStore{
+		path:    path,
+		current: initial,
+	}, nil
+}
+
+func (s *RuntimeSettingsStore) GetRuntimeSettings() (RuntimeSettings, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.current, nil
+}
+
+func (s *RuntimeSettingsStore) UpdateRuntimeSettings(next RuntimeSettings) (RuntimeSettings, error) {
+	if err := next.Validate(); err != nil {
+		return RuntimeSettings{}, err
+	}
+	if err := WriteRuntimeSettingsFile(s.path, next); err != nil {
+		return RuntimeSettings{}, err
+	}
+
+	s.mu.Lock()
+	s.current = next
+	s.mu.Unlock()
+	return next, nil
+}

--- a/internal/config/runtime_settings_test.go
+++ b/internal/config/runtime_settings_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeSettings_Validate(t *testing.T) {
+	valid := RuntimeSettings{
+		LLMAPIURL:      "https://example.test/v1",
+		LLMAPIKey:      "ak-test",
+		LLMModel:       "model-test",
+		CronExpr:       "*/5 * * * *",
+		TargetLanguage: "zh",
+	}
+	require.NoError(t, valid.Validate())
+
+	invalid := valid
+	invalid.CronExpr = "bad cron"
+	require.Error(t, invalid.Validate())
+
+	invalidLang := valid
+	invalidLang.TargetLanguage = ""
+	require.Error(t, invalidLang.Validate())
+}
+
+func TestRuntimeSettingsFile_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "settings", "runtime.json")
+	input := RuntimeSettings{
+		LLMAPIURL:      "https://example.test/v1",
+		LLMAPIKey:      "ak-test",
+		LLMModel:       "model-test",
+		CronExpr:       "0 0 * * *",
+		TargetLanguage: "zh",
+	}
+
+	require.NoError(t, WriteRuntimeSettingsFile(filePath, input))
+
+	got, err := LoadRuntimeSettingsFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, input, got)
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	assert.False(t, info.IsDir())
+}
+
+func TestWithRuntimeSettings_OverridesConfig(t *testing.T) {
+	t.Setenv("LLM_API_KEY", "env-key")
+	t.Setenv("LLM_API_URL", "https://env.example/v1")
+	t.Setenv("LLM_MODEL", "env-model")
+	t.Setenv("CRON_EXPR", "0 1 * * *")
+
+	override := RuntimeSettings{
+		LLMAPIURL:      "https://file.example/v1",
+		LLMAPIKey:      "file-key",
+		LLMModel:       "file-model",
+		CronExpr:       "*/30 * * * *",
+		TargetLanguage: "ja",
+	}
+
+	cfg, err := NewFromEnv(WithRuntimeSettings(override))
+	require.NoError(t, err)
+	assert.Equal(t, override.LLMAPIURL, cfg.LLM.APIURL)
+	assert.Equal(t, override.LLMAPIKey, cfg.LLM.APIKey)
+	assert.Equal(t, override.LLMModel, cfg.LLM.Model)
+	assert.Equal(t, override.CronExpr, cfg.Translate.CronExpr)
+	assert.Equal(t, "ja", cfg.Translate.TargetLanguage.String())
+}
+
+func TestRuntimeSettingsStore_UpdatePersistsFile(t *testing.T) {
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "runtime-settings.json")
+	initial := RuntimeSettings{
+		LLMAPIURL:      "https://old.example/v1",
+		LLMAPIKey:      "old-ak",
+		LLMModel:       "old-model",
+		CronExpr:       "0 0 * * *",
+		TargetLanguage: "zh",
+	}
+
+	store, err := NewRuntimeSettingsStore(filePath, initial)
+	require.NoError(t, err)
+
+	next := RuntimeSettings{
+		LLMAPIURL:      "https://new.example/v1",
+		LLMAPIKey:      "new-ak",
+		LLMModel:       "new-model",
+		CronExpr:       "*/10 * * * *",
+		TargetLanguage: "en",
+	}
+	got, err := store.UpdateRuntimeSettings(next)
+	require.NoError(t, err)
+	assert.Equal(t, next, got)
+
+	loaded, err := LoadRuntimeSettingsFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, next, loaded)
+}

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -1,0 +1,273 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/MimeLyc/contextual-sub-translator/internal/library"
+)
+
+func (s *Server) handleListSources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	lib, err := s.scanner.Scan(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, lib.Sources)
+}
+
+func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	lib, err := s.scanner.Scan(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	sourceID := r.URL.Query().Get("source")
+	if sourceID == "" {
+		writeJSON(w, http.StatusOK, lib.Items)
+		return
+	}
+
+	ret := make([]library.Item, 0)
+	for _, item := range lib.Items {
+		if item.SourceID == sourceID {
+			ret = append(ret, item)
+		}
+	}
+	writeJSON(w, http.StatusOK, ret)
+}
+
+func (s *Server) handleListEpisodesByItem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// /api/library/items/{id}/episodes
+	path := strings.TrimPrefix(r.URL.Path, "/api/library/items/")
+	if !strings.HasSuffix(path, "/episodes") {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	itemID := strings.TrimSuffix(path, "/episodes")
+	itemID = strings.TrimSuffix(itemID, "/")
+	if decoded, err := url.PathUnescape(itemID); err == nil {
+		itemID = decoded
+	}
+	if itemID == "" {
+		writeError(w, http.StatusBadRequest, "missing item id")
+		return
+	}
+
+	lib, err := s.scanner.Scan(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	activeJobsByMedia := inProgressJobsByMedia(s.queue.List())
+	ret := make([]episodeResponse, 0)
+	for _, episode := range lib.Episodes {
+		if episode.ItemID == itemID {
+			item := episodeResponse{
+				Episode: episode,
+			}
+			if job, ok := activeJobsByMedia[episode.MediaPath]; ok {
+				item.InProgress = true
+				item.JobStatus = job.Status
+				item.JobSource = job.Source
+			}
+			ret = append(ret, item)
+		}
+	}
+	writeJSON(w, http.StatusOK, episodesListResponse{
+		TargetLanguage: s.scanner.TargetLanguage(),
+		Episodes:       ret,
+	})
+}
+
+type episodesListResponse struct {
+	TargetLanguage string            `json:"target_language"`
+	Episodes       []episodeResponse `json:"episodes"`
+}
+
+type episodeResponse struct {
+	library.Episode
+	InProgress bool        `json:"in_progress"`
+	JobStatus  jobs.Status `json:"job_status,omitempty"`
+	JobSource  string      `json:"job_source,omitempty"`
+}
+
+func inProgressJobsByMedia(jobList []*jobs.TranslationJob) map[string]*jobs.TranslationJob {
+	ret := make(map[string]*jobs.TranslationJob)
+	for _, job := range jobList {
+		if job == nil || job.Payload.MediaFile == "" {
+			continue
+		}
+		if job.Status != jobs.StatusPending && job.Status != jobs.StatusRunning {
+			continue
+		}
+		existing, ok := ret[job.Payload.MediaFile]
+		if !ok || preferInProgressJob(job, existing) {
+			ret[job.Payload.MediaFile] = job
+		}
+	}
+	return ret
+}
+
+func preferInProgressJob(next, current *jobs.TranslationJob) bool {
+	nextRank := inProgressRank(next.Status)
+	currentRank := inProgressRank(current.Status)
+	if nextRank != currentRank {
+		return nextRank > currentRank
+	}
+	return next.UpdatedAt.After(current.UpdatedAt)
+}
+
+func inProgressRank(status jobs.Status) int {
+	switch status {
+	case jobs.StatusRunning:
+		return 2
+	case jobs.StatusPending:
+		return 1
+	default:
+		return 0
+	}
+}
+
+type enqueueJobRequest struct {
+	Source       string `json:"source"`
+	DedupeKey    string `json:"dedupe_key"`
+	MediaPath    string `json:"media_path"`
+	SubtitlePath string `json:"subtitle_path"`
+	NFOPath      string `json:"nfo_path"`
+}
+
+func (s *Server) handleJobs(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, s.queue.List())
+	case http.MethodPost:
+		var req enqueueJobRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		if req.Source == "" {
+			req.Source = "manual"
+		}
+		if req.MediaPath == "" {
+			writeError(w, http.StatusBadRequest, "media_path is required")
+			return
+		}
+		if req.DedupeKey == "" {
+			keySuffix := req.SubtitlePath
+			if keySuffix == "" {
+				keySuffix = "[embedded]"
+			}
+			req.DedupeKey = req.MediaPath + "|" + keySuffix
+		}
+
+		job, created := s.queue.Enqueue(jobs.EnqueueRequest{
+			Source:    req.Source,
+			DedupeKey: req.DedupeKey,
+			Payload: jobs.JobPayload{
+				MediaFile:    req.MediaPath,
+				SubtitleFile: req.SubtitlePath,
+				NFOFile:      req.NFOPath,
+			},
+		})
+		code := http.StatusCreated
+		if !created {
+			code = http.StatusOK
+		}
+		writeJSON(w, code, map[string]any{
+			"created": created,
+			"job":     job,
+		})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	s.scanner.Invalidate()
+	if _, err := s.scanner.Scan(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"ok": true,
+	})
+}
+
+func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	if s.settings == nil {
+		writeError(w, http.StatusNotImplemented, "settings store is not configured")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		settings, err := s.settings.GetRuntimeSettings()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, settings)
+	case http.MethodPut:
+		var req config.RuntimeSettings
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json body")
+			return
+		}
+		if err := req.Validate(); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		saved, err := s.settings.UpdateRuntimeSettings(req)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if s.apply != nil {
+			if err := s.apply(saved); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+		}
+		writeJSON(w, http.StatusOK, saved)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{
+		"error": msg,
+	})
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1,0 +1,124 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/MimeLyc/contextual-sub-translator/internal/library"
+)
+
+type runtimeSettingsStore interface {
+	GetRuntimeSettings() (config.RuntimeSettings, error)
+	UpdateRuntimeSettings(next config.RuntimeSettings) (config.RuntimeSettings, error)
+}
+
+type runtimeSettingsApplier func(next config.RuntimeSettings) error
+
+type Server struct {
+	scanner  *library.Scanner
+	queue    *jobs.Queue
+	settings runtimeSettingsStore
+	apply    runtimeSettingsApplier
+
+	uiEnabled   bool
+	uiStaticDir string
+
+	mux    *http.ServeMux
+	server *http.Server
+}
+
+type Option func(*Server)
+
+func WithUI(staticDir string, enabled bool) Option {
+	return func(s *Server) {
+		s.uiStaticDir = staticDir
+		s.uiEnabled = enabled
+	}
+}
+
+func WithRuntimeSettingsStore(store runtimeSettingsStore) Option {
+	return func(s *Server) {
+		s.settings = store
+	}
+}
+
+func WithRuntimeSettingsApplier(apply runtimeSettingsApplier) Option {
+	return func(s *Server) {
+		s.apply = apply
+	}
+}
+
+func NewServer(scanner *library.Scanner, queue *jobs.Queue, opts ...Option) *Server {
+	s := &Server{
+		scanner:   scanner,
+		queue:     queue,
+		uiEnabled: false,
+		mux:       http.NewServeMux(),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	s.routes()
+	return s
+}
+
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+func (s *Server) ListenAndServe(addr string) error {
+	s.server = &http.Server{
+		Addr:              addr,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s.server.ListenAndServe()
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.server == nil {
+		return nil
+	}
+	return s.server.Shutdown(ctx)
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("/api/library/sources", s.handleListSources)
+	s.mux.HandleFunc("/api/library/items", s.handleListItems)
+	s.mux.HandleFunc("/api/library/items/", s.handleListEpisodesByItem)
+	s.mux.HandleFunc("/api/jobs", s.handleJobs)
+	s.mux.HandleFunc("/api/jobs/stream", s.handleJobStream)
+	s.mux.HandleFunc("/api/scan", s.handleScan)
+	s.mux.HandleFunc("/api/settings", s.handleSettings)
+	s.mux.HandleFunc("/", s.handleStatic)
+}
+
+func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
+	if !s.uiEnabled || s.uiStaticDir == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	rel := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+	indexPath := filepath.Join(s.uiStaticDir, "index.html")
+
+	if rel == "" || !strings.Contains(filepath.Base(rel), ".") {
+		http.ServeFile(w, r, indexPath)
+		return
+	}
+
+	filePath := filepath.Join(s.uiStaticDir, rel)
+	if _, err := os.Stat(filePath); err != nil {
+		// SPA fallback: non-existing static file path returns index
+		http.ServeFile(w, r, indexPath)
+		return
+	}
+	http.ServeFile(w, r, filePath)
+}

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1,0 +1,329 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/MimeLyc/contextual-sub-translator/internal/library"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+type fakeSettingsStore struct {
+	current   config.RuntimeSettings
+	updateErr error
+}
+
+func (f *fakeSettingsStore) GetRuntimeSettings() (config.RuntimeSettings, error) {
+	return f.current, nil
+}
+
+func (f *fakeSettingsStore) UpdateRuntimeSettings(next config.RuntimeSettings) (config.RuntimeSettings, error) {
+	if f.updateErr != nil {
+		return config.RuntimeSettings{}, f.updateErr
+	}
+	f.current = next
+	return f.current, nil
+}
+
+func TestServer_ListSources(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	queue := jobs.NewQueue(1)
+	srv := NewServer(scanner, queue)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/library/sources", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var sources []library.Source
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &sources))
+	require.Len(t, sources, 1)
+	require.Equal(t, "tvshows", sources[0].ID)
+}
+
+func TestServer_CreateJob_WithPayload(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	queue := jobs.NewQueue(1)
+	srv := NewServer(scanner, queue)
+
+	body := []byte(`{"source":"manual","dedupe_key":"m|s|zh","media_path":"/tmp/a.mkv","subtitle_path":"/tmp/a.srt","nfo_path":"/tmp/tvshow.nfo"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/jobs", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var ret struct {
+		Created bool                 `json:"created"`
+		Job     *jobs.TranslationJob `json:"job"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &ret))
+	require.True(t, ret.Created)
+	require.NotNil(t, ret.Job)
+	require.Equal(t, "m|s|zh", ret.Job.DedupeKey)
+	require.Equal(t, "/tmp/a.mkv", ret.Job.Payload.MediaFile)
+	require.Equal(t, "/tmp/a.srt", ret.Job.Payload.SubtitleFile)
+	require.Equal(t, "/tmp/tvshow.nfo", ret.Job.Payload.NFOFile)
+}
+
+func TestServer_CreateJob_RequiresMediaPath(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	queue := jobs.NewQueue(1)
+	srv := NewServer(scanner, queue)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/jobs", bytes.NewReader([]byte(`{"source":"manual"}`)))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestServer_ListEpisodes_IncludesCronInProgress(t *testing.T) {
+	tmp := t.TempDir()
+	showDir := filepath.Join(tmp, "tvshows", "The Show")
+	require.NoError(t, os.MkdirAll(showDir, 0o755))
+
+	mediaPath := filepath.Join(showDir, "episode01.mkv")
+	subtitlePath := filepath.Join(showDir, "episode01.srt")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("media"), 0o644))
+	require.NoError(t, os.WriteFile(subtitlePath, []byte("subtitle"), 0o644))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: filepath.Join(tmp, "tvshows")},
+		},
+		language.Chinese,
+	)
+
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lib.Items, 1)
+
+	queue := jobs.NewQueue(1)
+	job, created := queue.Enqueue(jobs.EnqueueRequest{
+		Source:    "cron",
+		DedupeKey: mediaPath + "|" + subtitlePath + "|zh",
+		Payload: jobs.JobPayload{
+			MediaFile:    mediaPath,
+			SubtitleFile: subtitlePath,
+		},
+	})
+	require.True(t, created)
+	require.NotNil(t, job)
+	require.Equal(t, jobs.StatusPending, job.Status)
+
+	srv := NewServer(scanner, queue)
+	itemID := url.PathEscape(lib.Items[0].ID)
+	req := httptest.NewRequest(http.MethodGet, "/api/library/items/"+itemID+"/episodes", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		TargetLanguage string `json:"target_language"`
+		Episodes       []struct {
+			ID         string      `json:"id"`
+			InProgress bool        `json:"in_progress"`
+			JobStatus  jobs.Status `json:"job_status"`
+			JobSource  string      `json:"job_source"`
+		} `json:"episodes"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "zh", resp.TargetLanguage)
+	require.Len(t, resp.Episodes, 1)
+	require.Equal(t, mediaPath, resp.Episodes[0].ID)
+	require.True(t, resp.Episodes[0].InProgress)
+	require.Equal(t, jobs.StatusPending, resp.Episodes[0].JobStatus)
+	require.Equal(t, "cron", resp.Episodes[0].JobSource)
+}
+
+func TestServer_GetSettings(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	store := &fakeSettingsStore{
+		current: config.RuntimeSettings{
+			LLMAPIURL:      "https://example.test/v1",
+			LLMAPIKey:      "ak-test",
+			LLMModel:       "model-test",
+			CronExpr:       "*/5 * * * *",
+			TargetLanguage: "zh",
+		},
+	}
+	srv := NewServer(scanner, jobs.NewQueue(1), WithRuntimeSettingsStore(store))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got config.RuntimeSettings
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, store.current, got)
+}
+
+func TestServer_UpdateSettings(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	store := &fakeSettingsStore{
+		current: config.RuntimeSettings{
+			LLMAPIURL:      "https://old.example/v1",
+			LLMAPIKey:      "old-ak",
+			LLMModel:       "old-model",
+			CronExpr:       "0 0 * * *",
+			TargetLanguage: "zh",
+		},
+	}
+	srv := NewServer(scanner, jobs.NewQueue(1), WithRuntimeSettingsStore(store))
+
+	body := []byte(`{"llm_api_url":"https://new.example/v1","llm_api_key":"new-ak","llm_model":"new-model","cron_expr":"*/10 * * * *","target_language":"en"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got config.RuntimeSettings
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "https://new.example/v1", got.LLMAPIURL)
+	require.Equal(t, "new-ak", got.LLMAPIKey)
+	require.Equal(t, "new-model", got.LLMModel)
+	require.Equal(t, "*/10 * * * *", got.CronExpr)
+	require.Equal(t, "en", got.TargetLanguage)
+	require.Equal(t, got, store.current)
+}
+
+func TestServer_UpdateSettings_StoreFailure(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	store := &fakeSettingsStore{
+		current: config.RuntimeSettings{
+			LLMAPIURL:      "https://old.example/v1",
+			LLMAPIKey:      "old-ak",
+			LLMModel:       "old-model",
+			CronExpr:       "0 0 * * *",
+			TargetLanguage: "zh",
+		},
+		updateErr: errors.New("save failed"),
+	}
+	srv := NewServer(scanner, jobs.NewQueue(1), WithRuntimeSettingsStore(store))
+
+	body := []byte(`{"llm_api_url":"https://new.example/v1","llm_api_key":"new-ak","llm_model":"new-model","cron_expr":"*/10 * * * *","target_language":"en"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestServer_UpdateSettings_AppliesRuntimeSettingsImmediately(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{
+			{ID: "tvshows", Name: "TV Shows", Path: sourcePath},
+		},
+		language.Chinese,
+	)
+
+	store := &fakeSettingsStore{
+		current: config.RuntimeSettings{
+			LLMAPIURL:      "https://old.example/v1",
+			LLMAPIKey:      "old-ak",
+			LLMModel:       "old-model",
+			CronExpr:       "0 0 * * *",
+			TargetLanguage: "zh",
+		},
+	}
+
+	var applied config.RuntimeSettings
+	var applyCalls int
+	srv := NewServer(
+		scanner,
+		jobs.NewQueue(1),
+		WithRuntimeSettingsStore(store),
+		WithRuntimeSettingsApplier(func(next config.RuntimeSettings) error {
+			applied = next
+			applyCalls++
+			return nil
+		}),
+	)
+
+	body := []byte(`{"llm_api_url":"https://new.example/v1","llm_api_key":"new-ak","llm_model":"new-model","cron_expr":"*/10 * * * *","target_language":"en"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 1, applyCalls)
+	require.Equal(t, "en", applied.TargetLanguage)
+	require.Equal(t, "*/10 * * * *", applied.CronExpr)
+}

--- a/internal/httpapi/sse.go
+++ b/internal/httpapi/sse.go
@@ -1,0 +1,55 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func (s *Server) handleJobStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	send := func() bool {
+		payload, err := json.Marshal(s.queue.List())
+		if err != nil {
+			return false
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !send() {
+		return
+	}
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			if !send() {
+				return
+			}
+		}
+	}
+}

--- a/internal/httpapi/static_test.go
+++ b/internal/httpapi/static_test.go
@@ -1,0 +1,41 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/MimeLyc/contextual-sub-translator/internal/library"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestServer_ServesSPAFromStaticDir(t *testing.T) {
+	tmp := t.TempDir()
+	staticDir := filepath.Join(tmp, "web")
+	require.NoError(t, os.MkdirAll(staticDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<html>spa</html>"), 0o644))
+
+	sourcePath := filepath.Join(tmp, "tvshows")
+	require.NoError(t, os.MkdirAll(sourcePath, 0o755))
+
+	scanner := library.NewScanner(
+		[]library.SourceConfig{{ID: "tvshows", Name: "TV Shows", Path: sourcePath}},
+		language.Chinese,
+	)
+	server := NewServer(scanner, jobs.NewQueue(1), WithUI(staticDir, true))
+
+	for _, url := range []string{"/", "/series/abc"} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		rec := httptest.NewRecorder()
+
+		server.Handler().ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "spa")
+	}
+}

--- a/internal/jobs/queue.go
+++ b/internal/jobs/queue.go
@@ -1,0 +1,269 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Executor func(ctx context.Context, job *TranslationJob) error
+
+type Queue struct {
+	workerCount int
+	maxJobs     int
+
+	mu         sync.RWMutex
+	jobs       map[string]*TranslationJob
+	dedupe     map[string]string
+	idCounter  uint64
+	started    bool
+	pendingIDs chan string
+	stopCh     chan struct{}
+	stopOnce   sync.Once
+	wg         sync.WaitGroup
+}
+
+func NewQueue(workerCount int) *Queue {
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+	return &Queue{
+		workerCount: workerCount,
+		maxJobs:     1000,
+		jobs:        make(map[string]*TranslationJob),
+		dedupe:      make(map[string]string),
+		pendingIDs:  make(chan string, 1024),
+		stopCh:      make(chan struct{}),
+	}
+}
+
+func (q *Queue) Enqueue(req EnqueueRequest) (*TranslationJob, bool) {
+	now := time.Now()
+
+	q.mu.Lock()
+	if id, ok := q.dedupe[req.DedupeKey]; ok {
+		if existing, exists := q.jobs[id]; exists {
+			snapshot := cloneJob(existing)
+			q.mu.Unlock()
+			return snapshot, false
+		}
+		delete(q.dedupe, req.DedupeKey)
+	}
+
+	id := fmt.Sprintf("job-%d", atomic.AddUint64(&q.idCounter, 1))
+	job := &TranslationJob{
+		ID:        id,
+		Source:    req.Source,
+		DedupeKey: req.DedupeKey,
+		Payload:   req.Payload,
+		Status:    StatusPending,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	q.jobs[id] = job
+	q.dedupe[req.DedupeKey] = id
+	started := q.started
+	snapshot := cloneJob(job)
+	q.mu.Unlock()
+
+	if started {
+		q.enqueuePendingID(id)
+	}
+	return snapshot, true
+}
+
+func (q *Queue) Get(id string) (*TranslationJob, bool) {
+	q.mu.RLock()
+	job, ok := q.jobs[id]
+	q.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	return cloneJob(job), true
+}
+
+func (q *Queue) List() []*TranslationJob {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	ret := make([]*TranslationJob, 0, len(q.jobs))
+	for _, job := range q.jobs {
+		ret = append(ret, cloneJob(job))
+	}
+	return ret
+}
+
+func (q *Queue) Start(exec Executor) {
+	q.mu.Lock()
+	if q.started {
+		q.mu.Unlock()
+		return
+	}
+	q.started = true
+
+	pending := make([]string, 0)
+	for id, job := range q.jobs {
+		if job.Status == StatusPending {
+			pending = append(pending, id)
+		}
+	}
+	q.mu.Unlock()
+
+	for _, id := range pending {
+		q.enqueuePendingID(id)
+	}
+
+	for range q.workerCount {
+		q.wg.Add(1)
+		go q.worker(exec)
+	}
+}
+
+func (q *Queue) Stop() {
+	q.stopOnce.Do(func() {
+		close(q.stopCh)
+		q.wg.Wait()
+	})
+}
+
+func (q *Queue) worker(exec Executor) {
+	defer q.wg.Done()
+
+	for {
+		select {
+		case <-q.stopCh:
+			return
+		case id := <-q.pendingIDs:
+			job, ok := q.markRunning(id)
+			if !ok {
+				continue
+			}
+
+			err := exec(context.Background(), job)
+			if err != nil {
+				q.markFailed(id, err)
+				continue
+			}
+			q.markSuccess(id)
+		}
+	}
+}
+
+func (q *Queue) enqueuePendingID(id string) {
+	select {
+	case q.pendingIDs <- id:
+	default:
+		go func() { q.pendingIDs <- id }()
+	}
+}
+
+func (q *Queue) markRunning(id string) (*TranslationJob, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	job, ok := q.jobs[id]
+	if !ok || job.Status != StatusPending {
+		return nil, false
+	}
+	job.Status = StatusRunning
+	job.UpdatedAt = time.Now()
+	return cloneJob(job), true
+}
+
+func (q *Queue) markSuccess(id string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	job, ok := q.jobs[id]
+	if !ok {
+		return
+	}
+	job.Status = StatusSuccess
+	job.Error = ""
+	job.UpdatedAt = time.Now()
+	q.releaseDedupeLocked(job)
+	q.pruneTerminalJobsLocked()
+}
+
+func (q *Queue) markFailed(id string, err error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	job, ok := q.jobs[id]
+	if !ok {
+		return
+	}
+	job.Status = StatusFailed
+	if err != nil {
+		job.Error = err.Error()
+	}
+	job.UpdatedAt = time.Now()
+	q.releaseDedupeLocked(job)
+	q.pruneTerminalJobsLocked()
+}
+
+func (q *Queue) releaseDedupeLocked(job *TranslationJob) {
+	if job == nil || job.DedupeKey == "" {
+		return
+	}
+	if id, ok := q.dedupe[job.DedupeKey]; ok && id == job.ID {
+		delete(q.dedupe, job.DedupeKey)
+	}
+}
+
+func (q *Queue) pruneTerminalJobsLocked() {
+	if q.maxJobs <= 0 || len(q.jobs) <= q.maxJobs {
+		return
+	}
+
+	type candidate struct {
+		id        string
+		updatedAt time.Time
+	}
+	terminal := make([]candidate, 0, len(q.jobs))
+	for id, job := range q.jobs {
+		if job == nil {
+			continue
+		}
+		if job.Status == StatusPending || job.Status == StatusRunning {
+			continue
+		}
+		terminal = append(terminal, candidate{id: id, updatedAt: job.UpdatedAt})
+	}
+	if len(terminal) == 0 {
+		return
+	}
+
+	sort.Slice(terminal, func(i, j int) bool {
+		return terminal[i].updatedAt.Before(terminal[j].updatedAt)
+	})
+
+	toRemove := len(q.jobs) - q.maxJobs
+	if toRemove <= 0 {
+		return
+	}
+	if toRemove > len(terminal) {
+		toRemove = len(terminal)
+	}
+
+	for i := 0; i < toRemove; i++ {
+		id := terminal[i].id
+		job := q.jobs[id]
+		if job != nil {
+			q.releaseDedupeLocked(job)
+		}
+		delete(q.jobs, id)
+	}
+}
+
+func cloneJob(job *TranslationJob) *TranslationJob {
+	if job == nil {
+		return nil
+	}
+	tmp := *job
+	return &tmp
+}

--- a/internal/jobs/queue_test.go
+++ b/internal/jobs/queue_test.go
@@ -1,0 +1,94 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue_Enqueue_DeduplicatesSameKey(t *testing.T) {
+	q := NewQueue(2)
+
+	jobA, createdA := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "ep1|sub1|zh",
+	})
+	jobB, createdB := q.Enqueue(EnqueueRequest{
+		Source:    "cron",
+		DedupeKey: "ep1|sub1|zh",
+	})
+
+	require.True(t, createdA)
+	require.False(t, createdB)
+	require.NotNil(t, jobA)
+	require.NotNil(t, jobB)
+	assert.Equal(t, jobA.ID, jobB.ID)
+}
+
+func TestQueue_Enqueue_AllowsRetryAfterFailure(t *testing.T) {
+	q := NewQueue(1)
+
+	var attempts int
+	q.Start(func(_ context.Context, _ *TranslationJob) error {
+		attempts++
+		if attempts == 1 {
+			return assert.AnError
+		}
+		return nil
+	})
+	defer q.Stop()
+
+	first, created := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "retry-key",
+	})
+	require.True(t, created)
+	require.NotNil(t, first)
+
+	require.Eventually(t, func() bool {
+		got, ok := q.Get(first.ID)
+		return ok && got != nil && got.Status == StatusFailed
+	}, time.Second, 10*time.Millisecond)
+
+	second, created := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "retry-key",
+	})
+	require.True(t, created)
+	require.NotNil(t, second)
+	assert.NotEqual(t, first.ID, second.ID)
+
+	require.Eventually(t, func() bool {
+		got, ok := q.Get(second.ID)
+		return ok && got != nil && got.Status == StatusSuccess
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestQueue_Enqueue_AllowsRetryAfterSuccess(t *testing.T) {
+	q := NewQueue(1)
+	q.Start(func(_ context.Context, _ *TranslationJob) error { return nil })
+	defer q.Stop()
+
+	first, created := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "done-key",
+	})
+	require.True(t, created)
+	require.NotNil(t, first)
+
+	require.Eventually(t, func() bool {
+		got, ok := q.Get(first.ID)
+		return ok && got != nil && got.Status == StatusSuccess
+	}, time.Second, 10*time.Millisecond)
+
+	second, created := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "done-key",
+	})
+	require.True(t, created)
+	require.NotNil(t, second)
+	assert.NotEqual(t, first.ID, second.ID)
+}

--- a/internal/jobs/types.go
+++ b/internal/jobs/types.go
@@ -1,0 +1,36 @@
+package jobs
+
+import "time"
+
+type Status string
+
+const (
+	StatusPending Status = "pending"
+	StatusRunning Status = "running"
+	StatusSuccess Status = "success"
+	StatusFailed  Status = "failed"
+	StatusSkipped Status = "skipped"
+)
+
+type EnqueueRequest struct {
+	Source    string
+	DedupeKey string
+	Payload   JobPayload
+}
+
+type JobPayload struct {
+	MediaFile    string `json:"media_file"`
+	SubtitleFile string `json:"subtitle_file"`
+	NFOFile      string `json:"nfo_file"`
+}
+
+type TranslationJob struct {
+	ID        string    `json:"id"`
+	Source    string    `json:"source"`
+	DedupeKey string    `json:"dedupe_key"`
+	Payload   JobPayload `json:"payload"`
+	Status    Status    `json:"status"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/internal/jobs/worker_test.go
+++ b/internal/jobs/worker_test.go
@@ -1,0 +1,28 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue_Worker_TransitionsStatus(t *testing.T) {
+	q := NewQueue(1)
+	q.Start(func(_ context.Context, _ *TranslationJob) error { return nil })
+	defer q.Stop()
+
+	job, _ := q.Enqueue(EnqueueRequest{
+		Source:    "manual",
+		DedupeKey: "k1",
+	})
+
+	require.Eventually(t, func() bool {
+		got, ok := q.Get(job.ID)
+		if !ok || got == nil {
+			return false
+		}
+		return got.Status == StatusSuccess
+	}, time.Second, 10*time.Millisecond)
+}

--- a/internal/library/scanner.go
+++ b/internal/library/scanner.go
@@ -1,0 +1,503 @@
+package library
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/text/language"
+)
+
+type EmbeddedDetector func(mediaPath string) (hasEmbeddedSubtitle bool, hasEmbeddedTargetSubtitle bool, languages []string)
+
+type scannerOptions struct {
+	embeddedDetector EmbeddedDetector
+	cacheTTL         time.Duration
+}
+
+type Option func(*scannerOptions)
+
+func WithEmbeddedDetector(detector EmbeddedDetector) Option {
+	return func(o *scannerOptions) {
+		o.embeddedDetector = detector
+	}
+}
+
+func WithCacheTTL(ttl time.Duration) Option {
+	return func(o *scannerOptions) {
+		o.cacheTTL = ttl
+	}
+}
+
+type scanCache struct {
+	version uint64
+	scanned time.Time
+	library *Library
+}
+
+type Scanner struct {
+	sources          []SourceConfig
+	targetLanguage   language.Tag
+	embeddedDetector EmbeddedDetector
+
+	mu            sync.RWMutex
+	cacheTTL      time.Duration
+	cache         *scanCache
+	configVersion uint64
+}
+
+func NewScanner(
+	sources []SourceConfig,
+	targetLanguage language.Tag,
+	opts ...Option,
+) *Scanner {
+	options := scannerOptions{
+		embeddedDetector: func(string) (bool, bool, []string) { return false, false, nil },
+		cacheTTL:         5 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return &Scanner{
+		sources:          sources,
+		targetLanguage:   targetLanguage,
+		embeddedDetector: options.embeddedDetector,
+		cacheTTL:         options.cacheTTL,
+	}
+}
+
+func (s *Scanner) TargetLanguage() string {
+	s.mu.RLock()
+	target := s.targetLanguage
+	s.mu.RUnlock()
+
+	base, _ := target.Base()
+	return base.String()
+}
+
+func (s *Scanner) UpdateTargetLanguage(lang string) error {
+	tag, err := language.Parse(lang)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if s.targetLanguage != tag {
+		s.targetLanguage = tag
+		s.cache = nil
+		s.configVersion++
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *Scanner) Invalidate() {
+	s.mu.Lock()
+	s.cache = nil
+	s.configVersion++
+	s.mu.Unlock()
+}
+
+// resolveSeriesPath walks from the media file's directory upward toward
+// sourcePath, looking for a tvshow.nfo file. If found, that directory is the
+// series root. Otherwise falls back to the first subdirectory under sourcePath.
+func resolveSeriesPath(sourcePath, mediaPath string) string {
+	dir := filepath.Dir(mediaPath)
+	for dir != sourcePath && strings.HasPrefix(dir, sourcePath) {
+		nfo := filepath.Join(dir, "tvshow.nfo")
+		if _, err := os.Stat(nfo); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	// Fallback: first subdirectory under sourcePath.
+	// If media is directly in source dir, use source dir itself.
+	rel, err := filepath.Rel(sourcePath, filepath.Dir(mediaPath))
+	if err != nil || rel == "." {
+		return sourcePath
+	}
+	first := strings.SplitN(rel, string(filepath.Separator), 2)[0]
+	return filepath.Join(sourcePath, first)
+}
+
+// resolveSeasonName returns the season directory name (e.g. "Season 1")
+// if the media file is nested inside a subdirectory of seriesPath.
+// Returns "" if media is directly inside seriesPath.
+func resolveSeasonName(seriesPath, mediaPath string) string {
+	mediaDir := filepath.Dir(mediaPath)
+	if mediaDir == seriesPath {
+		return ""
+	}
+	rel, err := filepath.Rel(seriesPath, mediaDir)
+	if err != nil || rel == "." {
+		return ""
+	}
+	first := strings.SplitN(rel, string(filepath.Separator), 2)[0]
+	return first
+}
+
+var sonarrPattern = regexp.MustCompile(`(?i)S\d+E(\d+)`)
+var qualitySuffixPattern = regexp.MustCompile(`(?i)\s*[-. ](WEBRip|WEBDL|WEB-DL|BluRay|BDRip|HDRip|DVDRip|HDTV|AMZN|NF|DSNP|HULU|ATVP|PMTP|IT|DDP?\d|AAC|x264|x265|HEVC|H\.?264|H\.?265|10bit|\d{3,4}p).*$`)
+
+// cleanEpisodeName parses Sonarr-style filenames and produces a short display name.
+// e.g. "Gachiakuta - S01E15 - Clash! WEBRip-1080p" -> "E15 Clash!"
+func cleanEpisodeName(basename string) string {
+	m := sonarrPattern.FindStringSubmatchIndex(basename)
+	if m == nil {
+		return basename
+	}
+	epNum := basename[m[2]:m[3]]
+	// Everything after the S##E## pattern marker
+	after := strings.TrimSpace(basename[m[1]:])
+	after = strings.TrimLeft(after, "-. ")
+	after = strings.TrimSpace(after)
+	// Strip quality suffixes
+	after = qualitySuffixPattern.ReplaceAllString(after, "")
+	after = strings.TrimSpace(after)
+	if after != "" {
+		return "E" + epNum + " " + after
+	}
+	return "E" + epNum
+}
+
+func (s *Scanner) Scan(ctx context.Context) (*Library, error) {
+	s.mu.RLock()
+	version := s.configVersion
+	cacheTTL := s.cacheTTL
+	if s.cache != nil && s.cache.version == version && (cacheTTL <= 0 || time.Since(s.cache.scanned) < cacheTTL) {
+		cached := cloneLibrary(s.cache.library)
+		s.mu.RUnlock()
+		return cached, nil
+	}
+	sources := append([]SourceConfig(nil), s.sources...)
+	targetLanguage := s.targetLanguage
+	embeddedDetector := s.embeddedDetector
+	s.mu.RUnlock()
+
+	ret := &Library{
+		Sources:  make([]Source, 0, len(sources)),
+		Items:    make([]Item, 0),
+		Episodes: make([]Episode, 0),
+	}
+
+	for _, sourceCfg := range sources {
+		if sourceCfg.Path == "" {
+			continue
+		}
+		if _, err := os.Stat(sourceCfg.Path); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		source := Source{
+			ID:   sourceCfg.ID,
+			Name: sourceCfg.Name,
+			Path: sourceCfg.Path,
+		}
+
+		itemIdxByPath := make(map[string]int)
+
+		mediaFiles, err := findMediaFiles(sourceCfg.Path)
+		if err != nil {
+			return nil, err
+		}
+		for _, mediaPath := range mediaFiles {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			itemPath := resolveSeriesPath(sourceCfg.Path, mediaPath)
+			itemIdx, ok := itemIdxByPath[itemPath]
+			if !ok {
+				item := Item{
+					ID:       sourceCfg.ID + "|" + itemPath,
+					SourceID: sourceCfg.ID,
+					Name:     filepath.Base(itemPath),
+					Path:     itemPath,
+				}
+				ret.Items = append(ret.Items, item)
+				itemIdx = len(ret.Items) - 1
+				itemIdxByPath[itemPath] = itemIdx
+			}
+
+			baseName := strings.TrimSuffix(filepath.Base(mediaPath), filepath.Ext(mediaPath))
+			mediaDir := filepath.Dir(mediaPath)
+			sourceSubs, targetSubs, extLangs, err := findExternalSubtitles(mediaDir, baseName, targetLanguage)
+			if err != nil {
+				return nil, err
+			}
+
+			hasEmbedded, hasEmbeddedTarget, embeddedLangs := embeddedDetector(mediaPath)
+			hasEmbeddedTarget = hasEmbeddedTarget || embeddedLanguagesContainTarget(embeddedLangs, targetLanguage)
+			hasSource := len(sourceSubs) > 0 || hasEmbedded
+			hasTarget := len(targetSubs) > 0 || hasEmbeddedTarget
+
+			// Merge external and embedded languages (deduplicated, normalized)
+			languages := extLangs
+			seen := make(map[string]bool, len(extLangs))
+			for _, l := range extLangs {
+				seen[l] = true
+			}
+			for _, l := range embeddedLangs {
+				normalized := normalizeLangCode(l)
+				if normalized == "" {
+					continue
+				}
+				if !seen[normalized] {
+					seen[normalized] = true
+					languages = append(languages, normalized)
+				}
+			}
+
+			episode := Episode{
+				ID:        mediaPath,
+				SourceID:  sourceCfg.ID,
+				ItemID:    ret.Items[itemIdx].ID,
+				Name:      cleanEpisodeName(baseName),
+				Season:    resolveSeasonName(itemPath, mediaPath),
+				MediaPath: mediaPath,
+				Subtitles: SubtitleStatus{
+					HasSourceSubtitle:         hasSource,
+					HasTargetSubtitle:         hasTarget,
+					HasEmbeddedSubtitle:       hasEmbedded,
+					HasEmbeddedTargetSubtitle: hasEmbeddedTarget,
+					SourceSubtitleFiles:       sourceSubs,
+					TargetSubtitleFiles:       targetSubs,
+					Languages:                 languages,
+				},
+				Translatable: hasSource && !hasTarget,
+			}
+			ret.Episodes = append(ret.Episodes, episode)
+			ret.Items[itemIdx].EpisodeCount++
+		}
+
+		source.ItemCount = len(itemIdxByPath)
+		ret.Sources = append(ret.Sources, source)
+	}
+
+	s.mu.Lock()
+	if s.configVersion == version {
+		s.cache = &scanCache{
+			version: version,
+			scanned: time.Now(),
+			library: cloneLibrary(ret),
+		}
+	}
+	s.mu.Unlock()
+
+	return ret, nil
+}
+
+var subtitleExts = []string{
+	".srt", ".ass", ".ssa", ".vtt", ".sub", ".idx", ".sup", ".txt",
+}
+
+var mediaExts = []string{
+	".mkv", ".mp4", ".m4v", ".mov", ".avi", ".wmv", ".flv", ".webm",
+	".ogv", ".3gp", ".3g2", ".f4v", ".asf", ".rm", ".rmvb", ".ts",
+	".m2ts", ".mts", ".vob", ".mpg", ".mpeg", ".m2v", ".divx", ".xvid",
+}
+
+func findMediaFiles(root string) ([]string, error) {
+	ret := make([]string, 0)
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if slices.Contains(mediaExts, ext) {
+			ret = append(ret, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func findExternalSubtitles(dir string, mediaBase string, target language.Tag) (sourceSubs []string, targetSubs []string, languages []string, err error) {
+	sourceSubs = make([]string, 0)
+	targetSubs = make([]string, 0)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	seen := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if !slices.Contains(subtitleExts, ext) {
+			continue
+		}
+		stem := strings.TrimSuffix(name, ext)
+		if !subtitleMatchesMediaBase(stem, mediaBase) {
+			continue
+		}
+
+		token := subtitleLangToken(stem, mediaBase)
+		if lang := normalizeLangCode(token); lang != "" && !seen[lang] {
+			seen[lang] = true
+			languages = append(languages, lang)
+		}
+
+		fullPath := filepath.Join(dir, name)
+		if token != "" && isTargetLanguage(token, target) {
+			targetSubs = append(targetSubs, fullPath)
+			continue
+		}
+		sourceSubs = append(sourceSubs, fullPath)
+	}
+
+	return sourceSubs, targetSubs, languages, nil
+}
+
+func subtitleLangToken(stem, mediaBase string) string {
+	remain := strings.TrimPrefix(stem, mediaBase)
+	remain = strings.TrimLeft(remain, "._- ")
+	if remain == "" {
+		return ""
+	}
+
+	parts := strings.FieldsFunc(remain, func(r rune) bool {
+		return r == '.' || r == '_' || r == ' '
+	})
+	for i := len(parts) - 1; i >= 0; i-- {
+		token := strings.ToLower(parts[i])
+		if isLanguageToken(token) {
+			return token
+		}
+	}
+	return ""
+}
+
+// normalizeLangCode validates a language token and returns its normalized
+// ISO 639-1 base code (e.g. "fre"→"fr", "eng"→"en", "chi"→"zh").
+// Returns "" if the token is not a recognized language code.
+func normalizeLangCode(token string) string {
+	if token == "" {
+		return ""
+	}
+	tag, err := language.Parse(token)
+	if err != nil {
+		return ""
+	}
+	base, conf := tag.Base()
+	if conf == language.No {
+		return ""
+	}
+	return base.String()
+}
+
+func isTargetLanguage(token string, target language.Tag) bool {
+	token = strings.ToLower(strings.ReplaceAll(token, "_", "-"))
+	if token == "" {
+		return false
+	}
+
+	base, _ := target.Base()
+	targetBase := strings.ToLower(base.String())
+	if token == targetBase || strings.HasPrefix(token, targetBase+"-") {
+		return true
+	}
+
+	// common aliases
+	switch targetBase {
+	case "zh":
+		return token == "chi" || token == "chs" || token == "cht"
+	case "en":
+		return token == "eng"
+	}
+
+	return false
+}
+
+func subtitleMatchesMediaBase(stem, mediaBase string) bool {
+	if stem == mediaBase {
+		return true
+	}
+	if !strings.HasPrefix(stem, mediaBase) || len(stem) <= len(mediaBase) {
+		return false
+	}
+	switch stem[len(mediaBase)] {
+	case '.', '_', '-', ' ':
+		return true
+	default:
+		return false
+	}
+}
+
+func isLanguageToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	if normalizeLangCode(token) != "" {
+		return true
+	}
+	switch token {
+	case "chs", "cht":
+		return true
+	default:
+		return false
+	}
+}
+
+func embeddedLanguagesContainTarget(languages []string, target language.Tag) bool {
+	for _, lang := range languages {
+		if lang == "" {
+			continue
+		}
+		if isTargetLanguage(lang, target) {
+			return true
+		}
+		if normalized := normalizeLangCode(lang); normalized != "" && isTargetLanguage(normalized, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneLibrary(src *Library) *Library {
+	if src == nil {
+		return nil
+	}
+
+	dst := &Library{
+		Sources:  make([]Source, len(src.Sources)),
+		Items:    make([]Item, len(src.Items)),
+		Episodes: make([]Episode, len(src.Episodes)),
+	}
+	copy(dst.Sources, src.Sources)
+	copy(dst.Items, src.Items)
+	copy(dst.Episodes, src.Episodes)
+
+	for i := range dst.Episodes {
+		dst.Episodes[i].Subtitles.SourceSubtitleFiles = append([]string(nil), src.Episodes[i].Subtitles.SourceSubtitleFiles...)
+		dst.Episodes[i].Subtitles.TargetSubtitleFiles = append([]string(nil), src.Episodes[i].Subtitles.TargetSubtitleFiles...)
+		dst.Episodes[i].Subtitles.Languages = append([]string(nil), src.Episodes[i].Subtitles.Languages...)
+	}
+	return dst
+}

--- a/internal/library/scanner_test.go
+++ b/internal/library/scanner_test.go
@@ -1,0 +1,362 @@
+package library
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestScanner_EpisodeSubtitleFlags(t *testing.T) {
+	tmp := t.TempDir()
+	showDir := filepath.Join(tmp, "tvshows", "The Show", "Season 1")
+	require.NoError(t, os.MkdirAll(showDir, 0o755))
+
+	mediaPath := filepath.Join(showDir, "episode01.mkv")
+	srcSub := filepath.Join(showDir, "episode01.srt")
+	tgtSub := filepath.Join(showDir, "episode01.zh.srt")
+
+	require.NoError(t, os.WriteFile(mediaPath, []byte("media"), 0o644))
+	require.NoError(t, os.WriteFile(srcSub, []byte("source"), 0o644))
+	require.NoError(t, os.WriteFile(tgtSub, []byte("target"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{
+			{
+				ID:   "tvshows",
+				Name: "TV Shows",
+				Path: filepath.Join(tmp, "tvshows"),
+			},
+		},
+		language.Chinese,
+		WithEmbeddedDetector(func(string) (bool, bool, []string) {
+			return false, false, nil
+		}),
+	)
+
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, lib.Sources, 1)
+	require.Len(t, lib.Items, 1)
+	require.Len(t, lib.Episodes, 1)
+
+	// Item should resolve to series dir "The Show", not "Season 1"
+	assert.Equal(t, "The Show", lib.Items[0].Name)
+	assert.Equal(t, filepath.Join(tmp, "tvshows", "The Show"), lib.Items[0].Path)
+
+	ep := lib.Episodes[0]
+	assert.Equal(t, "Season 1", ep.Season)
+	assert.True(t, ep.Subtitles.HasSourceSubtitle)
+	assert.True(t, ep.Subtitles.HasTargetSubtitle)
+	assert.False(t, ep.Subtitles.HasEmbeddedSubtitle)
+	assert.False(t, ep.Subtitles.HasEmbeddedTargetSubtitle)
+	assert.False(t, ep.Translatable)
+	// "zh" recognized as valid language; plain .srt has no language token
+	assert.Equal(t, []string{"zh"}, ep.Subtitles.Languages)
+}
+
+func TestScanner_SeriesResolutionWithNFO(t *testing.T) {
+	tmp := t.TempDir()
+	seriesDir := filepath.Join(tmp, "animations", "Gachiakuta")
+	seasonDir := filepath.Join(seriesDir, "Season 1")
+	require.NoError(t, os.MkdirAll(seasonDir, 0o755))
+
+	// Place tvshow.nfo at series level
+	require.NoError(t, os.WriteFile(filepath.Join(seriesDir, "tvshow.nfo"), []byte("<tvshow/>"), 0o644))
+
+	mediaPath := filepath.Join(seasonDir, "Gachiakuta - S01E15 - Clash! WEBRip-1080p.mkv")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("media"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(seasonDir, "Gachiakuta - S01E15 - Clash! WEBRip-1080p.srt"),
+		[]byte("sub"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "anims", Name: "Animations", Path: filepath.Join(tmp, "animations")}},
+		language.Chinese,
+	)
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, lib.Items, 1)
+	assert.Equal(t, "Gachiakuta", lib.Items[0].Name)
+	assert.Equal(t, seriesDir, lib.Items[0].Path)
+
+	require.Len(t, lib.Episodes, 1)
+	ep := lib.Episodes[0]
+	assert.Equal(t, "Season 1", ep.Season)
+	assert.Equal(t, "E15 Clash!", ep.Name)
+}
+
+func TestScanner_MediaDirectlyInSeriesDir(t *testing.T) {
+	tmp := t.TempDir()
+	seriesDir := filepath.Join(tmp, "movies", "MyMovie")
+	require.NoError(t, os.MkdirAll(seriesDir, 0o755))
+
+	mediaPath := filepath.Join(seriesDir, "movie.mkv")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("media"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "movies", Name: "Movies", Path: filepath.Join(tmp, "movies")}},
+		language.Chinese,
+	)
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, lib.Items, 1)
+	assert.Equal(t, "MyMovie", lib.Items[0].Name)
+
+	require.Len(t, lib.Episodes, 1)
+	assert.Equal(t, "", lib.Episodes[0].Season)
+}
+
+func TestScanner_MultipleSeasons(t *testing.T) {
+	tmp := t.TempDir()
+	seriesDir := filepath.Join(tmp, "tv", "Show")
+	season1 := filepath.Join(seriesDir, "Season 1")
+	season2 := filepath.Join(seriesDir, "Season 2")
+	require.NoError(t, os.MkdirAll(season1, 0o755))
+	require.NoError(t, os.MkdirAll(season2, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(seriesDir, "tvshow.nfo"), []byte("<tvshow/>"), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(season1, "ep01.mkv"), []byte("m"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(season2, "ep01.mkv"), []byte("m"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "tv", Name: "TV", Path: filepath.Join(tmp, "tv")}},
+		language.Chinese,
+	)
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+
+	// Both episodes should be grouped under one item
+	require.Len(t, lib.Items, 1)
+	assert.Equal(t, "Show", lib.Items[0].Name)
+	assert.Equal(t, 2, lib.Items[0].EpisodeCount)
+
+	// Each episode has its own season
+	seasons := map[string]bool{}
+	for _, ep := range lib.Episodes {
+		seasons[ep.Season] = true
+	}
+	assert.True(t, seasons["Season 1"])
+	assert.True(t, seasons["Season 2"])
+}
+
+func TestScanner_LanguageFiltering(t *testing.T) {
+	tmp := t.TempDir()
+	showDir := filepath.Join(tmp, "shows", "Anime")
+	require.NoError(t, os.MkdirAll(showDir, 0o755))
+
+	mediaPath := filepath.Join(showDir, "ep01.mkv")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("m"), 0o644))
+	// _ctxtrans is a tool suffix, not a language — must be excluded
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "ep01_ctxtrans.srt"), []byte("s"), 0o644))
+	// fre (ISO 639-2 for French) — must normalize to "fr"
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "ep01.fre.srt"), []byte("s"), 0o644))
+	// eng → "en"
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "ep01.eng.srt"), []byte("s"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "shows", Name: "Shows", Path: filepath.Join(tmp, "shows")}},
+		language.Chinese,
+	)
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lib.Episodes, 1)
+
+	langs := lib.Episodes[0].Subtitles.Languages
+	assert.Contains(t, langs, "fr")
+	assert.Contains(t, langs, "en")
+	assert.NotContains(t, langs, "ctxtrans")
+	assert.NotContains(t, langs, "fre")
+	assert.NotContains(t, langs, "eng")
+	assert.NotContains(t, langs, "unknown")
+}
+
+func TestCleanEpisodeName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Gachiakuta - S01E15 - Clash! WEBRip-1080p", "E15 Clash!"},
+		{"Show - S02E03 - The Title", "E03 The Title"},
+		{"Show - S01E01 - Pilot HDTV-720p", "E01 Pilot"},
+		{"Show.S01E05.Episode.Name.1080p.WEB-DL", "E05 Episode.Name"},
+		{"S01E01", "E01"},
+		{"no-match-here", "no-match-here"},
+		{"Show - S01E12 - Title x264-GROUP", "E12 Title"},
+		{"Show - S01E08 - Title BluRay-1080p", "E08 Title"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, cleanEpisodeName(tt.input))
+		})
+	}
+}
+
+func TestResolveSeriesPath(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "source")
+	seriesDir := filepath.Join(sourcePath, "MySeries")
+	seasonDir := filepath.Join(seriesDir, "Season 1")
+	require.NoError(t, os.MkdirAll(seasonDir, 0o755))
+
+	t.Run("with tvshow.nfo", func(t *testing.T) {
+		nfoPath := filepath.Join(seriesDir, "tvshow.nfo")
+		require.NoError(t, os.WriteFile(nfoPath, []byte("<tvshow/>"), 0o644))
+		defer os.Remove(nfoPath)
+
+		mediaPath := filepath.Join(seasonDir, "ep01.mkv")
+		got := resolveSeriesPath(sourcePath, mediaPath)
+		assert.Equal(t, seriesDir, got)
+	})
+
+	t.Run("without tvshow.nfo fallback to first subdir", func(t *testing.T) {
+		mediaPath := filepath.Join(seasonDir, "ep01.mkv")
+		got := resolveSeriesPath(sourcePath, mediaPath)
+		assert.Equal(t, seriesDir, got)
+	})
+
+	t.Run("media directly in source dir", func(t *testing.T) {
+		mediaPath := filepath.Join(sourcePath, "movie.mkv")
+		got := resolveSeriesPath(sourcePath, mediaPath)
+		assert.Equal(t, sourcePath, got)
+	})
+}
+
+func TestResolveSeasonName(t *testing.T) {
+	tests := []struct {
+		name       string
+		seriesPath string
+		mediaPath  string
+		want       string
+	}{
+		{"nested season", "/tv/Show", "/tv/Show/Season 1/ep01.mkv", "Season 1"},
+		{"no season", "/tv/Show", "/tv/Show/ep01.mkv", ""},
+		{"deeply nested", "/tv/Show", "/tv/Show/Season 2/extras/ep01.mkv", "Season 2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveSeasonName(tt.seriesPath, tt.mediaPath))
+		})
+	}
+}
+
+func TestNormalizeLangCode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"en", "en"},
+		{"eng", "en"},
+		{"fre", "fr"},
+		{"fra", "fr"},
+		{"chi", "zh"},
+		{"zh", "zh"},
+		{"ja", "ja"},
+		{"jpn", "ja"},
+		{"ko", "ko"},
+		{"ctxtrans", ""},
+		{"forced", ""},
+		{"sdh", "sdh"}, // ISO 639-3 Shehri — valid language code
+		{"default", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeLangCode(tt.input))
+		})
+	}
+}
+
+func TestScanner_Scan_UsesCacheUntilInvalidate(t *testing.T) {
+	tmp := t.TempDir()
+	showDir := filepath.Join(tmp, "shows", "Anime")
+	require.NoError(t, os.MkdirAll(showDir, 0o755))
+
+	mediaPath := filepath.Join(showDir, "ep01.mkv")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("m"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "ep01.eng.srt"), []byte("s"), 0o644))
+
+	var detectorCalls atomic.Int32
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "shows", Name: "Shows", Path: filepath.Join(tmp, "shows")}},
+		language.Chinese,
+		WithEmbeddedDetector(func(string) (bool, bool, []string) {
+			detectorCalls.Add(1)
+			return false, false, nil
+		}),
+		WithCacheTTL(10*time.Second),
+	)
+
+	_, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	_, err = scanner.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), detectorCalls.Load())
+
+	scanner.Invalidate()
+	_, err = scanner.Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), detectorCalls.Load())
+}
+
+func TestScanner_SubtitleMatchRequiresBoundaryAfterMediaBase(t *testing.T) {
+	tmp := t.TempDir()
+	sourceDir := filepath.Join(tmp, "shows", "Series")
+	require.NoError(t, os.MkdirAll(sourceDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "ep1.mkv"), []byte("m"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "ep10.zh.srt"), []byte("s"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "shows", Name: "Shows", Path: filepath.Join(tmp, "shows")}},
+		language.Chinese,
+	)
+
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lib.Episodes, 1)
+
+	ep := lib.Episodes[0]
+	assert.Equal(t, filepath.Join(sourceDir, "ep1.mkv"), ep.MediaPath)
+	assert.False(t, ep.Subtitles.HasSourceSubtitle)
+	assert.False(t, ep.Subtitles.HasTargetSubtitle)
+	assert.False(t, ep.Translatable)
+}
+
+func TestScanner_UpdateTargetLanguage_TakesEffectImmediately(t *testing.T) {
+	tmp := t.TempDir()
+	showDir := filepath.Join(tmp, "shows", "Anime")
+	require.NoError(t, os.MkdirAll(showDir, 0o755))
+
+	mediaPath := filepath.Join(showDir, "ep01.mkv")
+	require.NoError(t, os.WriteFile(mediaPath, []byte("m"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(showDir, "ep01.eng.srt"), []byte("s"), 0o644))
+
+	scanner := NewScanner(
+		[]SourceConfig{{ID: "shows", Name: "Shows", Path: filepath.Join(tmp, "shows")}},
+		language.Chinese,
+		WithCacheTTL(10*time.Second),
+	)
+
+	lib, err := scanner.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lib.Episodes, 1)
+	assert.True(t, lib.Episodes[0].Translatable)
+
+	require.NoError(t, scanner.UpdateTargetLanguage("en"))
+
+	lib, err = scanner.Scan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lib.Episodes, 1)
+	assert.False(t, lib.Episodes[0].Translatable)
+	assert.True(t, lib.Episodes[0].Subtitles.HasTargetSubtitle)
+}

--- a/internal/library/types.go
+++ b/internal/library/types.go
@@ -1,0 +1,49 @@
+package library
+
+type SourceConfig struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type Source struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	ItemCount int    `json:"item_count"`
+}
+
+type Item struct {
+	ID           string `json:"id"`
+	SourceID     string `json:"source_id"`
+	Name         string `json:"name"`
+	Path         string `json:"path"`
+	EpisodeCount int    `json:"episode_count"`
+}
+
+type SubtitleStatus struct {
+	HasSourceSubtitle         bool     `json:"has_source_subtitle"`
+	HasTargetSubtitle         bool     `json:"has_target_subtitle"`
+	HasEmbeddedSubtitle       bool     `json:"has_embedded_subtitle"`
+	HasEmbeddedTargetSubtitle bool     `json:"has_embedded_target_subtitle"`
+	SourceSubtitleFiles       []string `json:"source_subtitle_files"`
+	TargetSubtitleFiles       []string `json:"target_subtitle_files"`
+	Languages                 []string `json:"languages"`
+}
+
+type Episode struct {
+	ID           string         `json:"id"`
+	SourceID     string         `json:"source_id"`
+	ItemID       string         `json:"item_id"`
+	Name         string         `json:"name"`
+	Season       string         `json:"season"`
+	MediaPath    string         `json:"media_path"`
+	Subtitles    SubtitleStatus `json:"subtitles"`
+	Translatable bool           `json:"translatable"`
+}
+
+type Library struct {
+	Sources  []Source  `json:"sources"`
+	Items    []Item    `json:"items"`
+	Episodes []Episode `json:"episodes"`
+}

--- a/internal/media/ffmpeg.go
+++ b/internal/media/ffmpeg.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/MimeLyc/contextual-sub-translator/internal/subtitle"
-	"github.com/MimeLyc/contextual-sub-translator/pkg/file"
 	"github.com/MimeLyc/contextual-sub-translator/pkg/log"
 	"golang.org/x/text/language"
 )
@@ -70,7 +70,7 @@ func (ff ffmpeg) ExtractSubtitle(
 		buf := make([]byte, 0, 10*1024*1024)
 		scanner.Buffer(buf, 100*1024*1024)
 		for scanner.Scan() {
-			log.Info(scanner.Text())
+			log.Info("%s", scanner.Text())
 		}
 		if err := scanner.Err(); err != nil && err.Error() != "read |0: file already closed" {
 			log.Error("Execution failed: %v", err)
@@ -88,11 +88,11 @@ func (ff ffmpeg) ExtractSubtitle(
 
 // Extract subtitle from media file and save to target path
 func (ff ffmpeg) DefExtractSubtitle() (string, error) {
+	ext := filepath.Ext(ff.fileName)
+	stem := strings.TrimSuffix(ff.fileName, ext)
 	return ff.ExtractSubtitle(
 		ff.fileDir,
-		// TODO
-		file.ReplaceExt(ff.fileName, "ctxtrans.srt"))
-
+		stem+"_ctxtrans.srt")
 }
 
 func (ff ffmpeg) ReadSubtitleDescription() (subtitle.Descriptions, error) {

--- a/internal/media/ffmpeg_test.go
+++ b/internal/media/ffmpeg_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MimeLyc/contextual-sub-translator/internal/subtitle"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/language"
 )
 
 // TestFFmpeg_ReadSubtitleDescription tests the ReadSubtitleDescription function
@@ -152,7 +153,16 @@ func TestFFmpeg_ReadSubtitleDescription(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, result)
+				assert.Len(t, result, len(tt.expected))
+				for i := range tt.expected {
+					assert.Equal(t, tt.expected[i].Language, result[i].Language)
+					assert.Equal(t, tt.expected[i].SubLanguage, result[i].SubLanguage)
+					if tt.expected[i].Language == "und" {
+						assert.Equal(t, language.Und, result[i].LangTag)
+					} else {
+						assert.NotEqual(t, language.Und, result[i].LangTag)
+					}
+				}
 			}
 		})
 	}

--- a/internal/service/job_integration_test.go
+++ b/internal/service/job_integration_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/MimeLyc/contextual-sub-translator/internal/jobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestManualAndCron_UseSameEnqueueDedup(t *testing.T) {
+	q := jobs.NewQueue(1)
+	svc := transService{
+		cfg: config.Config{
+			Translate: config.TranslateConfig{
+				TargetLanguage: language.Chinese,
+			},
+		},
+		jobQueue: q,
+	}
+
+	bundle := MediaPathBundle{
+		MediaFile:     "/media/episode01.mkv",
+		SubtitleFiles: []string{"/media/episode01.srt"},
+	}
+
+	jobFromCron, createdCron, err := svc.enqueueCronBundle(bundle)
+	require.NoError(t, err)
+	require.NotNil(t, jobFromCron)
+	require.True(t, createdCron)
+	assert.Equal(t, "/media/episode01.mkv", jobFromCron.Payload.MediaFile)
+	assert.Equal(t, "/media/episode01.srt", jobFromCron.Payload.SubtitleFile)
+
+	jobFromManual, createdManual, err := svc.enqueueManualBundle(bundle)
+	require.NoError(t, err)
+	require.NotNil(t, jobFromManual)
+	require.False(t, createdManual)
+
+	assert.Equal(t, jobFromCron.ID, jobFromManual.ID)
+	assert.Len(t, q.List(), 1)
+}

--- a/internal/service/runtime_settings_test.go
+++ b/internal/service/runtime_settings_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MimeLyc/contextual-sub-translator/internal/config"
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestTransService_ApplyRuntimeSettings_ReschedulesCronAndUpdatesConfig(t *testing.T) {
+	cronEngine := cron.New()
+	svc := NewRunnableTransService(
+		config.Config{
+			LLM: config.LLMConfig{
+				APIKey: "old-ak",
+				APIURL: "https://old.example/v1",
+				Model:  "old-model",
+			},
+			Translate: config.TranslateConfig{
+				TargetLanguage: language.Chinese,
+				CronExpr:       "0 0 * * *",
+			},
+		},
+		cronEngine,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, svc.Schedule(ctx))
+	require.Len(t, cronEngine.Entries(), 1)
+
+	err := svc.ApplyRuntimeSettings(config.RuntimeSettings{
+		LLMAPIURL:      "https://new.example/v1",
+		LLMAPIKey:      "new-ak",
+		LLMModel:       "new-model",
+		CronExpr:       "*/10 * * * *",
+		TargetLanguage: "en",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "*/10 * * * *", svc.cronExpr)
+	assert.Equal(t, "new-ak", svc.cfg.LLM.APIKey)
+	assert.Equal(t, "https://new.example/v1", svc.cfg.LLM.APIURL)
+	assert.Equal(t, "new-model", svc.cfg.LLM.Model)
+	assert.Equal(t, language.English, svc.cfg.Translate.TargetLanguage)
+	require.Len(t, cronEngine.Entries(), 1)
+}

--- a/internal/termmap/generator.go
+++ b/internal/termmap/generator.go
@@ -77,7 +77,8 @@ func (g *Generator) compileSearchResults(
 	)
 	userMessage := fmt.Sprintf(
 		"Here are search results about %q. Extract all %s -> %s term mappings "+
-			"(character names, places, terminology) and return them as a single JSON object:\n\n%s",
+			"(character names, places, terminology) and return them as a single JSON object. "+
+			"Do NOT call any tools; directly produce the JSON object from the provided search results:\n\n%s",
 		showInfo.Title, sourceLang, targetLang, searchData.String(),
 	)
 
@@ -85,7 +86,7 @@ func (g *Generator) compileSearchResults(
 	return g.agent.Execute(ctx, agent.AgentRequest{
 		SystemPrompt:  systemPrompt,
 		UserMessage:   userMessage,
-		MaxIterations: 1,
+		MaxIterations: 3,
 	})
 }
 
@@ -121,14 +122,15 @@ func (g *Generator) ExtractNewTerms(
 	)
 	userMessage := fmt.Sprintf(
 		"Here are search results about %q. Extract all %s -> %s term mappings "+
-			"(character names, places, terminology) and return them as a single JSON object:\n\n%s",
+			"(character names, places, terminology) and return them as a single JSON object. "+
+			"Do NOT call any tools; directly produce the JSON object from the provided search results:\n\n%s",
 		showTitle, sourceLang, targetLang, searchData.String(),
 	)
 
 	result, err := g.agent.Execute(ctx, agent.AgentRequest{
 		SystemPrompt:  systemPrompt,
 		UserMessage:   userMessage,
-		MaxIterations: 1,
+		MaxIterations: 3,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract terms from search results: %w", err)

--- a/verify-docker.sh
+++ b/verify-docker.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+echo "🚀 Docker validation script starting..."
+
+# Create test directory structure
+echo "📂 Creating test directories..."
+mkdir -p test/movies test/animations test/teleplays test/shows test/documentaries
+
+# Copy test files if they exist
+if [ -f "test.srt" ]; then
+    echo "📝 Copying test subtitle file..."
+    cp test.srt test/movies/demo-movie.srt
+fi
+
+# Build the image
+echo "🔨 Building Docker image..."
+docker-compose build
+
+# Validate image contents
+echo "🔍 Validating image contents..."
+docker run --rm -it ctxtrans:latest ffmpeg -version || echo "❌ ffmpeg not properly installed"
+docker run --rm -it ctxtrans:latest ffprobe -version || echo "❌ ffprobe not properly installed"
+
+# Check environment variables
+echo "⚙️  Checking environment variables..."
+docker run --rm ctxtrans:latest env | grep LLM_
+
+# Run tests if API key is provided
+test_api_key() {
+    if [ -n "$LLM_API_KEY" ]; then
+        echo "🔑 LLM_API_KEY is set, running service test..."
+        docker-compose up -d
+
+        sleep 5
+
+        # Check service status
+        docker-compose ps
+
+        # Get logs
+        echo "📋 Service logs:"
+        docker-compose logs --tail=50 ctxtrans
+
+        # Cleanup
+        docker-compose down
+    else
+        echo "ℹ️  LLM_API_KEY not set, skipping service runtime test."
+        echo "   You can set LLM_API_KEY environment variable to test full service:"
+        echo "   export LLM_API_KEY=your_actual_api_key"
+        echo "   ./verify-docker.sh"
+    fi
+}
+
+# Manual testing examples
+echo "📋 Manual testing examples:"
+echo "  1. Run interactive shell: docker-compose run --rm ctxtrans sh"
+echo "  2. Check ffmpeg: docker-compose run --rm ctxtrans ffmpeg -version"
+echo "  3. Check filesystem: docker-compose run --rm ctxtrans ls -la /movies"
+echo "  4. Environment variables test: docker-compose run --rm ctxtrans printenv"
+
+test_api_key
+
+echo "✅ Docker validation complete!"

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contextual Subtitle Translator</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1244 @@
+{
+  "name": "contextual-sub-translator-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "contextual-sub-translator-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "vue": "^3.5.18",
+        "vue-router": "^4.5.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.1.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
+      "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.28",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
+      "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.28",
+        "@vue/shared": "3.5.28"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
+      "integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.28",
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/compiler-ssr": "3.5.28",
+        "@vue/shared": "3.5.28",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.28.tgz",
+      "integrity": "sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/shared": "3.5.28"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
+      "integrity": "sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.28"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.28.tgz",
+      "integrity": "sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.28",
+        "@vue/shared": "3.5.28"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.28.tgz",
+      "integrity": "sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.28",
+        "@vue/runtime-core": "3.5.28",
+        "@vue/shared": "3.5.28",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.28.tgz",
+      "integrity": "sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.28",
+        "@vue/shared": "3.5.28"
+      },
+      "peerDependencies": {
+        "vue": "3.5.28"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
+      "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
+      "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.28",
+        "@vue/compiler-sfc": "3.5.28",
+        "@vue/runtime-dom": "3.5.28",
+        "@vue/server-renderer": "3.5.28",
+        "@vue/shared": "3.5.28"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "contextual-sub-translator-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="app-shell">
+    <aside class="app-sidebar">
+      <div class="brand">Contextual Subtitle Translator</div>
+      <nav class="side-nav">
+        <RouterLink to="/library">Library</RouterLink>
+        <RouterLink to="/jobs">Jobs</RouterLink>
+        <RouterLink to="/settings">Settings</RouterLink>
+      </nav>
+    </aside>
+    <main class="content">
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts"></script>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,137 @@
+export interface Source {
+  id: string;
+  name: string;
+  path: string;
+  item_count: number;
+}
+
+export interface Item {
+  id: string;
+  source_id: string;
+  name: string;
+  path: string;
+  episode_count: number;
+}
+
+export interface SubtitleStatus {
+  has_source_subtitle: boolean;
+  has_target_subtitle: boolean;
+  has_embedded_subtitle: boolean;
+  has_embedded_target_subtitle: boolean;
+  source_subtitle_files: string[];
+  target_subtitle_files: string[];
+  languages: string[];
+}
+
+export interface Episode {
+  id: string;
+  source_id: string;
+  item_id: string;
+  name: string;
+  season: string;
+  media_path: string;
+  subtitles: SubtitleStatus;
+  translatable: boolean;
+  in_progress?: boolean;
+  job_status?: Job["status"];
+  job_source?: string;
+}
+
+export interface Job {
+  id: string;
+  source: string;
+  dedupe_key: string;
+  payload: JobPayload;
+  status: "pending" | "running" | "success" | "failed" | "skipped";
+  error?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JobPayload {
+  media_file: string;
+  subtitle_file: string;
+  nfo_file: string;
+}
+
+export interface RuntimeSettings {
+  llm_api_url: string;
+  llm_api_key: string;
+  llm_model: string;
+  cron_expr: string;
+  target_language: string;
+}
+
+export interface CreateJobRequest {
+  source: string;
+  dedupeKey: string;
+  mediaPath: string;
+  subtitlePath?: string;
+  nfoPath?: string;
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {})
+    }
+  });
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || `request failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function listSources(): Promise<Source[]> {
+  return request<Source[]>("/api/library/sources");
+}
+
+export function listItems(sourceId: string): Promise<Item[]> {
+  const q = new URLSearchParams({ source: sourceId });
+  return request<Item[]>(`/api/library/items?${q.toString()}`);
+}
+
+export interface EpisodesResponse {
+  target_language: string;
+  episodes: Episode[];
+}
+
+export function listEpisodes(itemId: string): Promise<EpisodesResponse> {
+  return request<EpisodesResponse>(`/api/library/items/${encodeURIComponent(itemId)}/episodes`);
+}
+
+export function listJobs(): Promise<Job[]> {
+  return request<Job[]>("/api/jobs");
+}
+
+export async function createJob(req: CreateJobRequest): Promise<Job> {
+  const ret = await request<{ created: boolean; job: Job }>("/api/jobs", {
+    method: "POST",
+    body: JSON.stringify({
+      source: req.source,
+      dedupe_key: req.dedupeKey,
+      media_path: req.mediaPath,
+      subtitle_path: req.subtitlePath || "",
+      nfo_path: req.nfoPath || ""
+    })
+  });
+  return ret.job;
+}
+
+export async function triggerScan(): Promise<void> {
+  await request<{ ok: boolean }>("/api/scan", { method: "POST" });
+}
+
+export function getSettings(): Promise<RuntimeSettings> {
+  return request<RuntimeSettings>("/api/settings");
+}
+
+export function updateSettings(settings: RuntimeSettings): Promise<RuntimeSettings> {
+  return request<RuntimeSettings>("/api/settings", {
+    method: "PUT",
+    body: JSON.stringify(settings)
+  });
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import router from "./router";
+import "./styles.css";
+
+createApp(App).use(router).mount("#app");

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -1,0 +1,20 @@
+import { createRouter, createWebHistory } from "vue-router";
+import LibraryView from "./views/LibraryView.vue";
+import SourceView from "./views/SourceView.vue";
+import SeriesView from "./views/SeriesView.vue";
+import JobsView from "./views/JobsView.vue";
+import SettingsView from "./views/SettingsView.vue";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", redirect: "/library" },
+    { path: "/library", component: LibraryView },
+    { path: "/library/:sourceId", component: SourceView, props: true },
+    { path: "/series/:itemId", component: SeriesView, props: true },
+    { path: "/jobs", component: JobsView },
+    { path: "/settings", component: SettingsView }
+  ]
+});
+
+export default router;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,349 @@
+:root {
+  --bg: #f3f5f0;
+  --card: #ffffff;
+  --ink: #152017;
+  --muted: #5f7463;
+  --line: #d9e3d6;
+  --brand: #275d3f;
+  --brand-ink: #f4fff6;
+  --warn: #a66f14;
+  --bad: #9a2c2c;
+  --ok: #246f3a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  margin: 0;
+  min-height: 100%;
+  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  color: var(--ink);
+  background: radial-gradient(circle at 20% 10%, #eaf5e7, var(--bg));
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  min-height: 100vh;
+}
+
+.app-sidebar {
+  border-right: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.8);
+  padding: 20px 14px;
+}
+
+.brand {
+  margin-bottom: 18px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.side-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.side-nav a {
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 9px 10px;
+  color: var(--muted);
+}
+
+.side-nav a.router-link-active {
+  background: var(--brand);
+  color: var(--brand-ink);
+  border-color: var(--brand);
+}
+
+.content {
+  padding: 20px;
+}
+
+.panel {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.row-gap {
+  display: flex;
+  gap: 8px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 14px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.source-btn {
+  border: 1px solid var(--line);
+  background: #f7faf6;
+  border-radius: 10px;
+  padding: 10px;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.source-btn.active {
+  background: var(--brand);
+  color: var(--brand-ink);
+  border-color: var(--brand);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.item-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+  background: #fcfffb;
+}
+
+.item-card h3 {
+  margin: 0 0 8px;
+}
+
+.item-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.btn {
+  border: 1px solid var(--line);
+  background: #ffffff;
+  border-radius: 9px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--brand);
+  color: var(--brand-ink);
+  border-color: var(--brand);
+}
+
+.episode-list,
+.job-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.episode-row,
+.job-row {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  background: #fbfdfb;
+}
+
+.season-heading {
+  margin: 18px 0 6px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.season-heading:first-child {
+  margin-top: 0;
+}
+
+.episode-main {
+  flex: 1;
+}
+
+.status-col {
+  flex-shrink: 0;
+  min-width: 90px;
+  text-align: center;
+}
+
+.episode-title,
+.job-id {
+  font-weight: 600;
+}
+
+.job-key {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  font-size: 12px;
+  border-radius: 999px;
+  padding: 3px 9px;
+  border: 1px solid var(--line);
+  background: #f7faf6;
+}
+
+.chip.ok {
+  color: var(--ok);
+  border-color: #b7ddc0;
+  background: #edf9ef;
+}
+
+.chip.warn {
+  color: var(--warn);
+  border-color: #e8d0a7;
+  background: #fff7e8;
+}
+
+.chip.bad {
+  color: var(--bad);
+  border-color: #e7b1b1;
+  background: #fff1f1;
+}
+
+.settings-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.field input,
+.field select {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 9px 10px;
+  background: #fcfffb;
+  color: var(--ink);
+}
+
+.settings-message {
+  margin: 12px 0 0;
+  color: var(--muted);
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.breadcrumb-link {
+  color: var(--muted);
+}
+
+.breadcrumb-link:hover {
+  color: var(--brand);
+}
+
+.breadcrumb-sep {
+  color: var(--muted);
+}
+
+.empty-msg {
+  color: var(--muted);
+  margin: 0;
+}
+
+.lang-col {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+  min-width: 80px;
+}
+
+.lang-tag {
+  font-size: 12px;
+  border-radius: 999px;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  background: #f7faf6;
+}
+
+.lang-tag.target {
+  color: var(--ok);
+  border-color: #b7ddc0;
+  background: #edf9ef;
+  font-weight: 600;
+}
+
+.lang-tag.missing-target {
+  color: var(--muted);
+  border-color: var(--line);
+  background: #f7faf6;
+  font-style: italic;
+}
+
+.no-subs {
+  color: var(--muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .side-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/views/JobsView.vue
+++ b/web/src/views/JobsView.vue
@@ -1,0 +1,60 @@
+<template>
+  <section class="panel">
+    <div class="panel-head">
+      <h1>Jobs</h1>
+      <div class="row-gap">
+        <button class="btn" @click="refresh">Refresh</button>
+      </div>
+    </div>
+
+    <div class="job-list">
+      <article v-for="job in jobs" :key="job.id" class="job-row">
+        <div>
+          <div class="job-id">{{ job.id }}</div>
+          <div class="job-key">{{ job.dedupe_key }}</div>
+        </div>
+        <div class="chips">
+          <span class="chip" :class="statusClass(job.status)">{{ job.status }}</span>
+          <span v-if="job.error" class="chip bad">{{ job.error }}</span>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import { listJobs, type Job } from "../api";
+
+const jobs = ref<Job[]>([]);
+let evt: EventSource | null = null;
+
+function statusClass(status: string) {
+  if (status === "success") return "ok";
+  if (status === "running" || status === "pending") return "warn";
+  return "bad";
+}
+
+async function refresh() {
+  jobs.value = await listJobs();
+}
+
+onMounted(async () => {
+  await refresh();
+  evt = new EventSource("/api/jobs/stream");
+  evt.onmessage = (event) => {
+    try {
+      jobs.value = JSON.parse(event.data) as Job[];
+    } catch {
+      // ignore malformed payload
+    }
+  };
+});
+
+onUnmounted(() => {
+  if (evt) {
+    evt.close();
+    evt = null;
+  }
+});
+</script>

--- a/web/src/views/LibraryView.vue
+++ b/web/src/views/LibraryView.vue
@@ -1,0 +1,32 @@
+<template>
+  <section class="panel">
+    <div class="panel-head">
+      <h1>Media Library</h1>
+      <button class="btn" @click="refresh">Refresh</button>
+    </div>
+    <div class="cards">
+      <RouterLink
+        v-for="source in sources"
+        :key="source.id"
+        class="item-card"
+        :to="`/library/${source.id}`"
+      >
+        <h3>{{ source.name }}</h3>
+        <p>{{ source.item_count }} items</p>
+      </RouterLink>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { listSources, type Source } from "../api";
+
+const sources = ref<Source[]>([]);
+
+async function refresh() {
+  sources.value = await listSources();
+}
+
+onMounted(refresh);
+</script>

--- a/web/src/views/SeriesView.vue
+++ b/web/src/views/SeriesView.vue
@@ -1,0 +1,197 @@
+<template>
+  <section class="panel">
+    <div class="panel-head">
+      <div class="breadcrumb">
+        <router-link class="breadcrumb-link" to="/">Library</router-link>
+        <span class="breadcrumb-sep">/</span>
+        <span>{{ seriesName }}</span>
+      </div>
+      <div class="row-gap">
+        <button class="btn" @click="refresh">Reload</button>
+        <button class="btn btn-primary" :disabled="selectedCount === 0" @click="submitSelected">
+          Translate {{ selectedCount }} Selected
+        </button>
+      </div>
+    </div>
+
+    <div class="episode-list">
+      <template v-for="group in seasonGroups" :key="group.season">
+        <h3 v-if="showSeasonHeadings" class="season-heading">{{ group.label }}</h3>
+        <label v-for="ep in group.episodes" :key="ep.id" class="episode-row">
+          <input
+            v-model="selectedEpisodeIds"
+            type="checkbox"
+            :value="ep.id"
+            :disabled="!ep.translatable || !!ep.in_progress"
+          />
+          <div class="episode-main">
+            <div class="episode-title">{{ ep.name }}</div>
+          </div>
+          <div class="status-col">
+            <span class="chip" :class="statusClass(ep)">{{ statusLabel(ep) }}</span>
+          </div>
+          <div class="lang-col" :title="langTooltip(ep)">
+            <template v-if="langList(ep).length > 0">
+              <span
+                v-for="lang in langList(ep)"
+                :key="lang"
+                class="lang-tag"
+                :class="langClass(lang)"
+              >{{ lang }}</span>
+            </template>
+            <span v-else class="no-subs">No subtitles</span>
+          </div>
+        </label>
+      </template>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRoute } from "vue-router";
+import { createJob, listEpisodes, type Episode } from "../api";
+
+const route = useRoute();
+const episodes = ref<Episode[]>([]);
+const targetLanguage = ref("");
+const selectedEpisodeIds = ref<string[]>([]);
+const selectedCount = computed(() => selectedEpisodeIds.value.length);
+let evt: EventSource | null = null;
+
+const seriesName = computed(() => {
+  const rawItemId = route.params.itemId as string;
+  const decoded = decodeURIComponent(rawItemId);
+  const parts = decoded.split("|");
+  const path = parts.length > 1 ? parts[1] : decoded;
+  const segments = path.split("/").filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : decoded;
+});
+
+interface SeasonGroup {
+  season: string;
+  label: string;
+  episodes: Episode[];
+}
+
+const seasonGroups = computed<SeasonGroup[]>(() => {
+  const groups = new Map<string, Episode[]>();
+  for (const ep of episodes.value) {
+    const key = ep.season || "";
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key)!.push(ep);
+  }
+
+  const result: SeasonGroup[] = [];
+  for (const [season, eps] of groups) {
+    eps.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+    result.push({
+      season,
+      label: season || "Episodes",
+      episodes: eps,
+    });
+  }
+
+  result.sort((a, b) => a.season.localeCompare(b.season, undefined, { numeric: true }));
+  return result;
+});
+
+const showSeasonHeadings = computed(() => {
+  const groups = seasonGroups.value;
+  if (groups.length === 0) return false;
+  if (groups.length === 1 && groups[0].season === "") return false;
+  return true;
+});
+
+function statusLabel(ep: Episode): string {
+  if (!ep.subtitles.has_source_subtitle) return "No Source";
+  if (ep.in_progress) return ep.job_source === "cron" ? "Cron Translating" : "Translating";
+  if (ep.subtitles.has_target_subtitle) return "Translated";
+  return "Pending";
+}
+
+function statusClass(ep: Episode): string {
+  if (!ep.subtitles.has_source_subtitle) return "bad";
+  if (ep.in_progress) return "warn";
+  if (ep.subtitles.has_target_subtitle) return "ok";
+  return "";
+}
+
+function langList(ep: Episode): string[] {
+  const langs = ep.subtitles.languages || [];
+  if (langs.length === 0) return [];
+  const tgt = targetLanguage.value;
+  if (!tgt) return langs;
+  const sorted = [...langs].sort((a, b) => {
+    const aIsTarget = isTargetLang(a) ? 0 : 1;
+    const bIsTarget = isTargetLang(b) ? 0 : 1;
+    return aIsTarget - bIsTarget;
+  });
+  return sorted;
+}
+
+function isTargetLang(lang: string): boolean {
+  const tgt = targetLanguage.value;
+  if (!tgt) return false;
+  return lang === tgt || lang.startsWith(tgt + "-");
+}
+
+function langClass(lang: string): string {
+  if (isTargetLang(lang)) return "target";
+  return "";
+}
+
+function langTooltip(ep: Episode): string {
+  const langs = ep.subtitles.languages || [];
+  if (langs.length === 0) return "No subtitles detected";
+  return langs.join(", ");
+}
+
+function dedupeKey(ep: Episode): string {
+  const sourceSub = ep.subtitles.source_subtitle_files[0] || "[embedded]";
+  return `${ep.media_path}|${sourceSub}|${targetLanguage.value || "zh"}`;
+}
+
+async function refresh() {
+  const rawItemId = route.params.itemId as string;
+  const resp = await listEpisodes(decodeURIComponent(rawItemId));
+  episodes.value = resp.episodes || [];
+  targetLanguage.value = resp.target_language || "";
+  selectedEpisodeIds.value = selectedEpisodeIds.value.filter((id) =>
+    episodes.value.some((ep) => ep.id === id && ep.translatable && !ep.in_progress)
+  );
+}
+
+async function submitSelected() {
+  const selected = episodes.value.filter(
+    (ep) => selectedEpisodeIds.value.includes(ep.id) && ep.translatable && !ep.in_progress
+  );
+  for (const ep of selected) {
+    await createJob({
+      source: "manual",
+      dedupeKey: dedupeKey(ep),
+      mediaPath: ep.media_path,
+      subtitlePath: ep.subtitles.source_subtitle_files[0] || ""
+    });
+  }
+  selectedEpisodeIds.value = [];
+  await refresh();
+}
+
+onMounted(async () => {
+  await refresh();
+  evt = new EventSource("/api/jobs/stream");
+  evt.onmessage = () => {
+    void refresh();
+  };
+});
+
+onUnmounted(() => {
+  if (evt) {
+    evt.close();
+    evt = null;
+  }
+});
+</script>

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -1,0 +1,119 @@
+<template>
+  <section class="panel">
+    <div class="panel-head">
+      <h1>Settings</h1>
+      <div class="row-gap">
+        <button class="btn" :disabled="loading || saving" @click="reload">Reload</button>
+        <button class="btn btn-primary" :disabled="loading || saving" @click="save">Save</button>
+      </div>
+    </div>
+
+    <div class="settings-form">
+      <label class="field">
+        <span>LLM API URL</span>
+        <input v-model.trim="form.llm_api_url" type="text" placeholder="https://example.com/v1" />
+      </label>
+
+      <label class="field">
+        <span>LLM API Key</span>
+        <input v-model.trim="form.llm_api_key" type="password" placeholder="sk-..." />
+      </label>
+
+      <label class="field">
+        <span>Model</span>
+        <input v-model.trim="form.llm_model" type="text" placeholder="openai/gpt-4o-mini" />
+      </label>
+
+      <label class="field">
+        <span>Cron Expression</span>
+        <input v-model.trim="form.cron_expr" type="text" placeholder="0 0 * * *" />
+      </label>
+
+      <label class="field">
+        <span>Target Language</span>
+        <select v-model="form.target_language">
+          <option value="" disabled>Select language</option>
+          <option value="zh">Chinese (zh)</option>
+          <option value="en">English (en)</option>
+          <option value="ja">Japanese (ja)</option>
+          <option value="ko">Korean (ko)</option>
+          <option value="fr">French (fr)</option>
+          <option value="de">German (de)</option>
+          <option value="es">Spanish (es)</option>
+          <option value="pt">Portuguese (pt)</option>
+          <option value="ru">Russian (ru)</option>
+          <option value="it">Italian (it)</option>
+          <option value="ar">Arabic (ar)</option>
+          <option value="th">Thai (th)</option>
+          <option value="vi">Vietnamese (vi)</option>
+        </select>
+      </label>
+    </div>
+
+    <p v-if="message" class="settings-message">{{ message }}</p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from "vue";
+import { getSettings, updateSettings, type RuntimeSettings } from "../api";
+
+const loading = ref(false);
+const saving = ref(false);
+const message = ref("");
+
+const form = reactive<RuntimeSettings>({
+  llm_api_url: "",
+  llm_api_key: "",
+  llm_model: "",
+  cron_expr: "",
+  target_language: ""
+});
+
+async function loadSettings() {
+  loading.value = true;
+  message.value = "";
+  try {
+    const settings = await getSettings();
+    form.llm_api_url = settings.llm_api_url || "";
+    form.llm_api_key = settings.llm_api_key || "";
+    form.llm_model = settings.llm_model || "";
+    form.cron_expr = settings.cron_expr || "";
+    form.target_language = settings.target_language || "";
+  } catch (err) {
+    message.value = err instanceof Error ? err.message : "Failed to load settings";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function reload() {
+  await loadSettings();
+}
+
+async function save() {
+  saving.value = true;
+  message.value = "";
+  try {
+    const saved = await updateSettings({
+      llm_api_url: form.llm_api_url,
+      llm_api_key: form.llm_api_key,
+      llm_model: form.llm_model,
+      cron_expr: form.cron_expr,
+      target_language: form.target_language
+    });
+    form.llm_api_url = saved.llm_api_url || "";
+    form.llm_api_key = saved.llm_api_key || "";
+    form.llm_model = saved.llm_model || "";
+    form.cron_expr = saved.cron_expr || "";
+    form.target_language = saved.target_language || "";
+    message.value = "Settings saved";
+  } catch (err) {
+    message.value = err instanceof Error ? err.message : "Failed to save settings";
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(loadSettings);
+</script>

--- a/web/src/views/SourceView.vue
+++ b/web/src/views/SourceView.vue
@@ -1,0 +1,50 @@
+<template>
+  <section class="panel">
+    <div class="panel-head">
+      <div class="breadcrumb">
+        <RouterLink to="/library" class="breadcrumb-link">Library</RouterLink>
+        <span class="breadcrumb-sep">/</span>
+        <span>{{ sourceName }}</span>
+      </div>
+      <button class="btn" @click="refresh">Refresh</button>
+    </div>
+    <div class="cards">
+      <RouterLink
+        v-for="item in items"
+        :key="item.id"
+        class="item-card"
+        :to="`/series/${encodeURIComponent(item.id)}`"
+      >
+        <h3>{{ item.name }}</h3>
+        <p>{{ item.episode_count }} episodes</p>
+      </RouterLink>
+      <p v-if="items.length === 0 && !loading" class="empty-msg">No items found.</p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+import { listItems, listSources, type Item } from "../api";
+
+const route = useRoute();
+const items = ref<Item[]>([]);
+const sourceName = ref("");
+const loading = ref(false);
+
+async function refresh() {
+  loading.value = true;
+  const sourceId = route.params.sourceId as string;
+  try {
+    const sources = await listSources();
+    const source = sources.find((s) => s.id === sourceId);
+    sourceName.value = source?.name || sourceId;
+    items.value = await listItems(sourceId);
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(refresh);
+</script>

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    host: true,
+    port: 5173
+  }
+});


### PR DESCRIPTION

  This PR introduces a full web control plane for contextual-sub-translator,
  including a Vue-based UI, HTTP API, runtime settings persistence, and a
  background job queue.
  It also refactors the translation runtime from direct cron execution to
  queue-driven processing, adds library scanning and live job updates, and
  updates Docker/build workflows to ship backend + frontend together.
  Compared with origin/master, this is a large cross-cutting change (46 files,
  +5701 / -166) that adds new runtime behavior, APIs, and deployment paths.

  ## Risk Assessment

  - High: Surface area expansion — backend runtime, HTTP API, scanner, queue,
    and frontend are introduced in one PR.
  - High: Security/ops risk — settings endpoints are unauthenticated and
    include sensitive runtime config fields (e.g., API key) if deployed on
    untrusted networks.
  - Medium: Behavioral compatibility — subtitle output naming moved toward
    _ctxtrans convention, which may affect downstream tooling/scripts expecting
    old patterns.
  - Medium: Runtime dynamics — hot-updating cron/language and cached scan
    results can introduce stale windows or operator confusion if not
    documented.
  - Medium: Performance profile changed — library scans are now cached (TTL-
    based), reducing load but introducing short-lived stale reads.

  ## Functional Changes

  - Added a web UI (Library / Series / Jobs / Settings) for browsing media,
    submitting translation jobs, and editing runtime settings.
  - Added HTTP API for:
      - library discovery (/api/library/*)
      - jobs (/api/jobs, /api/jobs/stream)
      - manual scan trigger (/api/scan)
      - runtime settings read/write (/api/settings)
  - Added queue-based job execution with worker pool, dedupe, status
    transitions, retry-after-terminal behavior, and terminal-job pruning.
  - Added runtime settings persistence (settings.json) with validation and
    atomic writes.
  - Added runtime settings live-apply path to update cron schedule and scanner
    target language without restart.
  - Added library scanner with source/item/episode models, subtitle language
    detection, embedded subtitle checks, and scan caching/invalidation.
  - Updated Docker/Makefile/README to support web build + backend runtime
    together.

  ## Concrete Code Changes

  - cmd/main.go
      - boots settings store, queue, scanner, HTTP server
      - wires runtime settings apply callback into service + scanner
  - internal/httpapi/*
      - new API handlers, server bootstrap, SSE stream, SPA static serving
  - internal/jobs/*
      - new queue types/worker engine with dedupe + lifecycle management
  - internal/library/*
      - new scanner and data model; cache TTL + invalidate + target-language
        update support
      - stricter subtitle/media matching to avoid prefix false positives (e.g.,
        ep1 vs ep10)
  - internal/service/service.go
      - cron scheduling now queue-aware
      - runtime settings apply logic reschedules cron and updates active config
        safely
  - internal/config/runtime_settings.go
      - runtime settings model, validation, file load/store, thread-safe store
  - web/*
      - Vue + Vite app, routing, API client, pages, and styling
  - Build/runtime:
      - Dockerfile multi-stage build now includes frontend build artifacts
      - Makefile adds run workflow for local UI serving
      - README.md updated for HTTP/UI/config priority docs

