### PR TITLE
fix: skip invalid episode date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,13 @@ logs/
 coverage.out
 coverage.html
 
+# Local build/cache artifacts
+.cache/
+web/node_modules/
+web/dist/
+test/
+.env*
+findings.md
+ctxtrans
+docker-compose.yml
+progress.md


### PR DESCRIPTION

  This PR hardens subtitle probing and changes media selection from file
  modification time to NFO-based release dates. It also fixes the startup
  search window logic to use the later timestamp between now-14d and the last
  cron trigger. In strict mode, bundles without a parseable release date are
  now skipped.

  ## Key Functional Changes

  - Improved ffprobe handling so non-zero exit codes can still be accepted when
    valid stream JSON is returned.
  - Switched source bundle discovery from modTime filtering to release-date
    filtering from NFO metadata.
  - Added strict filtering behavior: if no valid release date is found, the
    bundle is skipped.
  - Corrected startup window calculation to use max(now-14d, cronLast) instead
    of the earlier timestamp.
  - Added local artifact ignore rules in .gitignore.

  ## Code-Level Changes

  - internal/media/ffmpeg.go
  - internal/media/ffmpeg_test.go
  - internal/service/service.go
  - internal/service/service_test.go
  - .gitignore

  Detailed implementation:

  - ReadSubtitleDescription() now treats ffprobe failures as non-fatal only
    when output is present and contains parseable stream payload.
  - Added release-date extraction pipeline (aired / premiered / year) with date
    parsing helpers and episode-NFO priority.
  - Replaced recent-file scan (FindRecentAfter) with full candidate walk plus
    release-date filtering.
  - Bundle admission now requires a valid release date and that date must be
    within the computed window.
  - startTime() logic now returns the later value between rolling 14-day window
    and cron last trigger.

