### PR TITLE
perf: lazy loading of ffprob

### DIFF
--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -136,9 +136,9 @@ func TestServer_ListEpisodes_IncludesCronInProgress(t *testing.T) {
 		language.Chinese,
 	)
 
-	lib, err := scanner.Scan(context.Background())
+	items, err := scanner.ScanItems(context.Background(), "tvshows")
 	require.NoError(t, err)
-	require.Len(t, lib.Items, 1)
+	require.Len(t, items, 1)
 
 	queue := jobs.NewQueue(1)
 	job, created := queue.Enqueue(jobs.EnqueueRequest{
@@ -154,7 +154,7 @@ func TestServer_ListEpisodes_IncludesCronInProgress(t *testing.T) {
 	require.Equal(t, jobs.StatusPending, job.Status)
 
 	srv := NewServer(scanner, queue)
-	itemID := url.PathEscape(lib.Items[0].ID)
+	itemID := url.PathEscape(items[0].ID)
 	req := httptest.NewRequest(http.MethodGet, "/api/library/items/"+itemID+"/episodes", nil)
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)


### PR DESCRIPTION
 Summary

  This PR introduces a tiered, lazy-loading scanner architecture to replace the monolithic Scan() approach, significantly reducing API response latency by
  deferring expensive operations (ffprobe, subtitle detection) until actually needed. The original Scan() method is preserved for backward compatibility but
  HTTP handlers now use the new granular methods.

  Changes

  Functional Changes

  - New tiered scan methods (scanner.go): Added ScanSources(), ScanItems(sourceID), and ScanEpisodesByItem(itemID) — each performs only the minimum I/O
  required for its level:
    - ScanSources: reads top-level directories only (no ffprobe)
    - ScanItems: reads media file counts per directory (no ffprobe)
    - ScanEpisodesByItem: runs ffprobe and subtitle detection, but only for a single item
  - Per-tier caching: Independent caches with configurable TTLs (sources: 60s, items: 30s, episodes: 10s) instead of a single monolithic cache
  - Parallel ffprobe in ScanEpisodesByItem via errgroup with configurable concurrency (WithMaxConcurrency, default 8)
  - HTTP handler refactor (handlers.go): All three list endpoints (/sources, /items, /episodes) now call the new tiered methods instead of Scan()
  - Scan endpoint simplification (handleScan): Now only calls Invalidate() and returns 202 Accepted immediately — no longer blocks on a full re-scan

  Configuration Options Added

  - WithSourcesCacheTTL, WithItemsCacheTTL, WithEpisodesCacheTTL, WithMaxConcurrency
